### PR TITLE
fix: track bootstrap completion from widget responses

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,10 @@ use ratatui::{
     widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
 };
 use state::{
-    AppState, FLOW_ANIM_CELLS, FLOW_BOOTSTRAP_PHASES, FlowAnimKind, FlowAnimSegment, FlowDirection,
-    FlowLane, GPT_5_6_AND_EARLIER_USAGE_BUCKET, LogEntry, Mode, ServerUiEvent, SharedState,
-    ShowDetailMode, ToolMode, UsageTotals, app_config_path, flow_anim_lit_count,
-    load_ngrok_authtoken, load_ngrok_domain, save_ngrok_authtoken, save_ngrok_domain,
-    user_home_dir,
+    AppState, FLOW_ANIM_CELLS, FlowAnimKind, FlowAnimSegment, FlowDirection, FlowLane,
+    GPT_5_6_AND_EARLIER_USAGE_BUCKET, LogEntry, Mode, ServerUiEvent, SharedState, ShowDetailMode,
+    ToolMode, UsageTotals, app_config_path, flow_anim_lit_count, load_ngrok_authtoken,
+    load_ngrok_domain, save_ngrok_authtoken, save_ngrok_domain, user_home_dir,
 };
 use std::collections::HashMap;
 use std::io::{Write, stdout};
@@ -620,54 +619,126 @@ enum FlowPhaseStepState {
     Complete,
 }
 
-fn flow_phase_bounds(phase_index: usize) -> (usize, usize) {
-    let start = FLOW_BOOTSTRAP_PHASES
-        .iter()
-        .take(phase_index)
-        .map(|phase| phase.steps.len())
-        .sum::<usize>();
-    let end = start + FLOW_BOOTSTRAP_PHASES[phase_index].steps.len();
-    (start, end)
+struct FlowPhaseStepView {
+    label: String,
+    state: FlowPhaseStepState,
 }
 
-fn flow_phase_step_state(flow: Option<&FlowLane>, step_index: usize) -> FlowPhaseStepState {
-    let Some(flow) = flow else {
-        return FlowPhaseStepState::Future;
-    };
-    if step_index < flow.bootstrap_completed_steps {
+struct FlowPhaseView {
+    title: &'static str,
+    complete: bool,
+    steps: Vec<FlowPhaseStepView>,
+}
+
+fn flow_event_pending(flow: &FlowLane, event: &str, now_millis: u128) -> bool {
+    current_anim_segment(flow, now_millis).is_some() && latest_flow_action(flow) == event
+}
+
+fn flow_phase_step_view(
+    flow: Option<&FlowLane>,
+    event: &str,
+    label: String,
+    complete: bool,
+    now_millis: u128,
+) -> FlowPhaseStepView {
+    let state = if complete {
         FlowPhaseStepState::Complete
-    } else if flow.bootstrap_pending_steps.contains(&step_index) {
+    } else if flow.is_some_and(|flow| flow_event_pending(flow, event, now_millis)) {
         FlowPhaseStepState::Pending
     } else {
         FlowPhaseStepState::Future
-    }
+    };
+    FlowPhaseStepView { label, state }
 }
 
-fn flow_phase_status_label(flow: Option<&FlowLane>, phase_index: usize) -> Option<String> {
-    let Some(flow) = flow else {
-        return None;
-    };
-    let (start, end) = flow_phase_bounds(phase_index);
-    if flow.bootstrap_completed_steps >= end {
+fn flow_phase_views(
+    flow: Option<&FlowLane>,
+    mode: ShowDetailMode,
+    now_millis: u128,
+) -> Vec<FlowPhaseView> {
+    let discover_complete = flow.is_some_and(|flow| flow.bootstrap_progress.discover_complete);
+    let tools_list_complete = flow.is_some_and(|flow| flow.bootstrap_progress.tools_list_complete);
+    let mut phases = vec![FlowPhaseView {
+        title: "Connecting",
+        complete: discover_complete && tools_list_complete,
+        steps: vec![
+            flow_phase_step_view(
+                flow,
+                "server/discover",
+                "discover".to_string(),
+                discover_complete,
+                now_millis,
+            ),
+            flow_phase_step_view(
+                flow,
+                "tools/list",
+                "tools/list".to_string(),
+                tools_list_complete,
+                now_millis,
+            ),
+        ],
+    }];
+
+    if mode != ShowDetailMode::Disable {
+        let steps = flow
+            .map(|flow| {
+                flow.bootstrap_progress
+                    .expected_widgets
+                    .iter()
+                    .map(|widget| {
+                        let event = format!("resources/read:{}", widget.tool_name);
+                        flow_phase_step_view(
+                            Some(flow),
+                            &event,
+                            widget.label.clone(),
+                            flow.bootstrap_progress
+                                .loaded_widget_uris
+                                .contains(&widget.uri),
+                            now_millis,
+                        )
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let complete = flow.is_some_and(|flow| {
+            flow.bootstrap_progress.tools_list_complete
+                && flow
+                    .bootstrap_progress
+                    .expected_widgets
+                    .iter()
+                    .all(|widget| {
+                        flow.bootstrap_progress
+                            .loaded_widget_uris
+                            .contains(&widget.uri)
+                    })
+        });
+        phases.push(FlowPhaseView {
+            title: "Loading widgets",
+            complete,
+            steps,
+        });
+    }
+
+    phases
+}
+
+fn flow_phase_status_label(phase: &FlowPhaseView) -> Option<String> {
+    if phase.complete {
         return Some("✓".to_string());
     }
-    if let Some(step_index) = flow
-        .bootstrap_pending_steps
+    if let Some(step) = phase
+        .steps
         .iter()
-        .copied()
-        .find(|step_index| (start..end).contains(step_index))
+        .find(|step| step.state == FlowPhaseStepState::Pending)
     {
-        let step = &FLOW_BOOTSTRAP_PHASES[phase_index].steps[step_index - start];
-        return Some(step.label.to_string());
+        return Some(step.label.clone());
     }
-    if (start..end).contains(&flow.bootstrap_completed_steps.saturating_sub(1))
-        && flow.bootstrap_completed_steps > start
-    {
-        let step_index = flow.bootstrap_completed_steps - 1;
-        let step = &FLOW_BOOTSTRAP_PHASES[phase_index].steps[step_index - start];
-        return Some(step.label.to_string());
-    }
-    None
+    phase
+        .steps
+        .iter()
+        .rev()
+        .find(|step| step.state == FlowPhaseStepState::Complete)
+        .map(|step| step.label.clone())
 }
 
 fn flow_phase_lines(
@@ -675,14 +746,11 @@ fn flow_phase_lines(
     mode: ShowDetailMode,
     palette: &theme::Palette,
     status_style: Style,
+    now_millis: u128,
 ) -> Vec<Line<'static>> {
     const TITLE_STATUS_GAP: usize = 4;
     const STATUS_ANIM_GAP: usize = 4;
-    let phases = if mode == ShowDetailMode::Disable {
-        &FLOW_BOOTSTRAP_PHASES[..1]
-    } else {
-        FLOW_BOOTSTRAP_PHASES
-    };
+    let phases = flow_phase_views(flow, mode, now_millis);
     let title_width = phases
         .iter()
         .enumerate()
@@ -694,7 +762,7 @@ fn flow_phase_lines(
         .iter()
         .flat_map(|phase| {
             std::iter::once("✓".to_string())
-                .chain(phase.steps.iter().map(|step| step.label.to_string()))
+                .chain(phase.steps.iter().map(|step| step.label.clone()))
                 .map(|status| format!("[{status}]").chars().count())
         })
         .max()
@@ -714,8 +782,7 @@ fn flow_phase_lines(
         .map(|(phase_index, phase)| {
             let title = format!("    Phase {}  {}", phase_index + 1, phase.title);
             let title_padding = title_width.saturating_sub(title.chars().count());
-            let status_label = flow_phase_status_label(flow, phase_index);
-            let status_text = status_label
+            let status_text = flow_phase_status_label(phase)
                 .map(|label| format!("[{label}]"))
                 .unwrap_or_default();
             let status_padding = status_width.saturating_sub(status_text.chars().count());
@@ -725,13 +792,11 @@ fn flow_phase_lines(
                 Span::styled(status_text, status_style),
                 Span::styled(" ".repeat(status_padding + STATUS_ANIM_GAP), future_style),
             ];
-            let (start, _) = flow_phase_bounds(phase_index);
-            for (step_offset, _) in phase.steps.iter().enumerate() {
+            for (step_offset, step) in phase.steps.iter().enumerate() {
                 if step_offset > 0 {
                     spans.push(Span::raw(" "));
                 }
-                let step_index = start + step_offset;
-                match flow_phase_step_state(flow, step_index) {
+                match step.state {
                     FlowPhaseStepState::Future => {
                         spans.push(Span::styled("✧", future_style));
                     }
@@ -748,21 +813,12 @@ fn flow_phase_lines(
         .collect()
 }
 
-fn flow_bootstrap_steps_total(mode: state::ShowDetailMode) -> usize {
-    state::flow_bootstrap_steps_total(mode)
+fn flow_bootstrap_complete(flow: &FlowLane) -> bool {
+    flow.bootstrap_progress.is_complete()
 }
 
-fn flow_bootstrap_complete(flow: &FlowLane, mode: state::ShowDetailMode) -> bool {
-    flow.bootstrap_completed_steps >= flow_bootstrap_steps_total(mode)
-        && flow.bootstrap_pending_steps.is_empty()
-}
-
-fn flow_bootstrap_status_visible(
-    flow: &FlowLane,
-    now_millis: u128,
-    mode: state::ShowDetailMode,
-) -> bool {
-    if !flow_bootstrap_complete(flow, mode) {
+fn flow_bootstrap_status_visible(flow: &FlowLane, now_millis: u128) -> bool {
+    if !flow_bootstrap_complete(flow) {
         return true;
     }
     if current_anim_segment(flow, now_millis).is_some() {
@@ -785,7 +841,7 @@ fn active_bootstrap_status_flow<'a>(app: &'a AppState, now_millis: u128) -> Opti
         should_display_flow_row(flow, app.remote_connected)
             && flow.bootstrap_status_active
             && flow.closing_started_ms.is_none()
-            && flow_bootstrap_status_visible(flow, now_millis, app.show_detail_mode)
+            && flow_bootstrap_status_visible(flow, now_millis)
     })
 }
 
@@ -816,7 +872,7 @@ fn flow_bootstrap_status_lines(
     now_millis: u128,
 ) -> Vec<Line<'static>> {
     let action_label = latest_flow_action(flow);
-    let bootstrap_complete = flow_bootstrap_complete(flow, app.show_detail_mode);
+    let bootstrap_complete = flow_bootstrap_complete(flow);
     let header_title = if bootstrap_complete {
         "Bootstrap completed"
     } else {
@@ -875,6 +931,7 @@ fn flow_bootstrap_status_lines(
         Style::default()
             .fg(palette.info_fg)
             .add_modifier(Modifier::BOLD),
+        now_millis,
     ));
     lines.push(Line::from(""));
 
@@ -2435,19 +2492,26 @@ mod tests {
         let palette = super::theme::all()[0].palette;
         let status_style = ratatui::style::Style::default();
 
-        let disabled =
-            super::flow_phase_lines(None, super::ShowDetailMode::Disable, &palette, status_style);
+        let disabled = super::flow_phase_lines(
+            None,
+            super::ShowDetailMode::Disable,
+            &palette,
+            status_style,
+            0,
+        );
         let expanded = super::flow_phase_lines(
             None,
             super::ShowDetailMode::Expanded,
             &palette,
             status_style,
+            0,
         );
         let collapsed = super::flow_phase_lines(
             None,
             super::ShowDetailMode::Collapsed,
             &palette,
             status_style,
+            0,
         );
 
         assert_eq!(disabled.len(), 1);

--- a/src/main.rs
+++ b/src/main.rs
@@ -692,8 +692,8 @@ fn flow_phase_views(
                             &event,
                             widget.label.clone(),
                             flow.bootstrap_progress
-                                .loaded_widget_uris
-                                .contains(&widget.uri),
+                                .loaded_widget_tool_names
+                                .contains(&widget.tool_name),
                             now_millis,
                         )
                     })
@@ -702,15 +702,7 @@ fn flow_phase_views(
             .unwrap_or_default();
         let complete = flow.is_some_and(|flow| {
             flow.bootstrap_progress.tools_list_complete
-                && flow
-                    .bootstrap_progress
-                    .expected_widgets
-                    .iter()
-                    .all(|widget| {
-                        flow.bootstrap_progress
-                            .loaded_widget_uris
-                            .contains(&widget.uri)
-                    })
+                && flow.bootstrap_progress.widgets_complete()
         });
         phases.push(FlowPhaseView {
             title: "Loading widgets",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -334,6 +334,10 @@ fn current_widget_resource_uri() -> String {
     current_widget_resource_uri_for_tool("")
 }
 
+pub(crate) fn is_catdesk_widget_resource_uri(uri: &str) -> bool {
+    uri == UI_TEMPLATE_URI || uri.starts_with(&format!("{UI_TEMPLATE_URI}?"))
+}
+
 fn current_widget_resource_uri_for_tool(tool_name: &str) -> String {
     let token_stats_layout = current_token_stats_layout();
     if tool_name.is_empty() {
@@ -425,7 +429,7 @@ fn handle_resources_read_with_show_detail_mode(
     if show_detail_mode == ShowDetailMode::Disable {
         return JsonRpcResponse::error(req.id.clone(), -32602, format!("Unknown resource: {uri}"));
     }
-    let text = if uri == UI_TEMPLATE_URI || uri.starts_with(&format!("{UI_TEMPLATE_URI}?")) {
+    let text = if is_catdesk_widget_resource_uri(uri) {
         render_widget_html(uri, mascot_seed)
     } else {
         return JsonRpcResponse::error(req.id.clone(), -32602, format!("Unknown resource: {uri}"));

--- a/src/server.rs
+++ b/src/server.rs
@@ -1709,6 +1709,60 @@ mod tests {
         let _ = std::fs::remove_dir_all(config_root);
     }
 
+    #[tokio::test]
+    async fn post_mcp_tracks_widget_read_by_tool_name_across_uri_variations() {
+        let workspace_root = unique_temp_path("catdesk-bootstrap-read-workspace");
+        let config_root = unique_temp_path("catdesk-bootstrap-read-config");
+        let config_path = config_root.join("config.toml");
+        std::fs::create_dir_all(&workspace_root).expect("create workspace");
+        std::fs::create_dir_all(&config_root).expect("create config dir");
+
+        let app = AppState::new_for_test(
+            8787,
+            workspace_root.to_string_lossy().into_owned(),
+            config_path.clone(),
+        )
+        .expect("create app state");
+        let app_state = Arc::new(Mutex::new(app));
+        let (ui_tx, mut ui_rx) = unbounded_channel();
+        let server_state = ServerState {
+            app: app_state,
+            devtools: None,
+            command_jobs: CommandJobManager::new(),
+            ui_events: ui_tx,
+            catdesk_instruction_called: Arc::new(AtomicBool::new(true)),
+        };
+
+        let response = post_mcp(
+            State(server_state),
+            mcp_request_body(
+                "resources/read",
+                json!({
+                    "uri": "ui://widget/catdesk-dashboard.html?widgetRevision=999&tokenStatsLayout=bottom&toolName=read"
+                }),
+            ),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut tracked = None;
+        while let Ok(event) = ui_rx.try_recv() {
+            if let ServerUiEvent::RecordBootstrapWidgetReadResponse {
+                tool_name, success, ..
+            } = event
+            {
+                tracked = Some((tool_name, success));
+            }
+        }
+        let (tool_name, success) = tracked.expect("missing bootstrap resources/read event");
+        assert!(success);
+        assert_eq!(tool_name, "read");
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace_root);
+        let _ = std::fs::remove_dir_all(config_root);
+    }
+
     fn tool_call_body(name: &str, arguments: Value) -> Bytes {
         mcp_request_body(
             "tools/call",
@@ -2999,12 +3053,16 @@ async fn post_mcp_inner(
                     });
             }
             "resources/read" => {
-                if let Some(uri) = request_resource_uri(&body) {
+                if let Some(tool_name) = request_resource_uri(&body)
+                    .filter(|uri| mcp::is_catdesk_widget_resource_uri(uri))
+                    .and_then(|uri| query_param_value(uri, "toolName"))
+                    .filter(|tool_name| !tool_name.is_empty())
+                {
                     let _ = s
                         .ui_events
                         .send(ServerUiEvent::RecordBootstrapWidgetReadResponse {
                             flow_id: STATELESS_FLOW_ID.to_string(),
-                            uri: uri.to_string(),
+                            tool_name: tool_name.to_string(),
                             success: response_succeeded,
                         });
                 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,8 +19,8 @@ use crate::command_jobs::CommandJobManager;
 use crate::devtools::DevtoolsBridge;
 use crate::mcp::{self, JsonRpcRequest, WIDGET_PAYLOAD_META_KEY};
 use crate::state::{
-    AgentsPathMode, FlowDirection, ServerUiEvent, SharedState, ShowDetailMode, TokenStatsLayout,
-    UsageTotals, parse_seed_hex, save_agents_path_mode, save_show_detail_mode,
+    AgentsPathMode, FlowBootstrapWidget, FlowDirection, ServerUiEvent, SharedState, ShowDetailMode,
+    TokenStatsLayout, UsageTotals, parse_seed_hex, save_agents_path_mode, save_show_detail_mode,
     save_token_stats_layout,
 };
 
@@ -424,6 +424,39 @@ fn resource_read_flow_label(req: &Value) -> String {
         return format!("resources/read:{tool_name}");
     }
     "resources/read:base".to_string()
+}
+
+fn bootstrap_widgets_from_tools_list_response(response: &Value) -> Vec<FlowBootstrapWidget> {
+    let Some(tools) = response
+        .get("result")
+        .and_then(|result| result.get("tools"))
+        .and_then(Value::as_array)
+    else {
+        return Vec::new();
+    };
+
+    tools
+        .iter()
+        .filter_map(|tool| {
+            let tool_name = tool.get("name").and_then(Value::as_str)?;
+            let uri = tool
+                .get("_meta")
+                .and_then(|meta| meta.get("openai/outputTemplate"))
+                .and_then(Value::as_str)?;
+            if !mcp::is_catdesk_widget_resource_uri(uri) {
+                return None;
+            }
+            Some(FlowBootstrapWidget {
+                uri: uri.to_string(),
+                tool_name: tool_name.to_string(),
+                label: if tool_name == "catdesk_instruction" {
+                    "instruction".to_string()
+                } else {
+                    tool_name.to_string()
+                },
+            })
+        })
+        .collect()
 }
 
 fn request_flow_label(req: &Value) -> String {
@@ -1394,6 +1427,42 @@ mod tests {
     }
 
     #[test]
+    fn bootstrap_widget_discovery_uses_catdesk_output_templates_only() {
+        let response = json!({
+            "result": {
+                "tools": [
+                    {
+                        "name": "read",
+                        "_meta": {
+                            "openai/outputTemplate": "ui://widget/catdesk-dashboard.html?widgetRevision=2&toolName=read"
+                        }
+                    },
+                    {
+                        "name": "catdesk_instruction",
+                        "_meta": {
+                            "openai/outputTemplate": "ui://widget/catdesk-dashboard.html?widgetRevision=2&toolName=catdesk_instruction"
+                        }
+                    },
+                    {
+                        "name": "browser_tool",
+                        "_meta": {
+                            "openai/outputTemplate": "ui://other/widget.html"
+                        }
+                    },
+                    { "name": "plain_tool" }
+                ]
+            }
+        });
+
+        let widgets = bootstrap_widgets_from_tools_list_response(&response);
+        assert_eq!(widgets.len(), 2);
+        assert_eq!(widgets[0].tool_name, "read");
+        assert_eq!(widgets[0].label, "read");
+        assert_eq!(widgets[1].tool_name, "catdesk_instruction");
+        assert_eq!(widgets[1].label, "instruction");
+    }
+
+    #[test]
     fn tool_log_summary_omits_large_payload_text() {
         let request = json!({
             "jsonrpc": "2.0",
@@ -1561,6 +1630,79 @@ mod tests {
                 mcp::MODERN_MCP_PROTOCOL_VERSION
             )
         );
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace_root);
+        let _ = std::fs::remove_dir_all(config_root);
+    }
+
+    #[tokio::test]
+    async fn post_mcp_reports_runtime_widget_set_from_tools_list() {
+        let workspace_root = unique_temp_path("catdesk-bootstrap-tools-workspace");
+        let config_root = unique_temp_path("catdesk-bootstrap-tools-config");
+        let config_path = config_root.join("config.toml");
+        std::fs::create_dir_all(&workspace_root).expect("create workspace");
+        std::fs::create_dir_all(&config_root).expect("create config dir");
+
+        let app = AppState::new_for_test(
+            8787,
+            workspace_root.to_string_lossy().into_owned(),
+            config_path.clone(),
+        )
+        .expect("create app state");
+        let app_state = Arc::new(Mutex::new(app));
+        let (ui_tx, mut ui_rx) = unbounded_channel();
+        let server_state = ServerState {
+            app: app_state,
+            devtools: None,
+            command_jobs: CommandJobManager::new(),
+            ui_events: ui_tx,
+            catdesk_instruction_called: Arc::new(AtomicBool::new(true)),
+        };
+
+        let response = post_mcp(
+            State(server_state),
+            mcp_request_body("tools/list", json!({})),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let mut tracked = None;
+        while let Ok(event) = ui_rx.try_recv() {
+            if let ServerUiEvent::RecordBootstrapToolsListResponse {
+                success, widgets, ..
+            } = event
+            {
+                tracked = Some((success, widgets));
+            }
+        }
+        let (success, widgets) = tracked.expect("missing bootstrap tools/list event");
+        assert!(success);
+        assert_eq!(widgets.len(), 10);
+        assert_eq!(
+            widgets
+                .iter()
+                .map(|widget| widget.tool_name.as_str())
+                .collect::<Vec<_>>(),
+            vec![
+                "run_command",
+                "start_command",
+                "poll_command",
+                "cancel_command",
+                "catdesk_instruction",
+                "read",
+                "search",
+                "write",
+                "edit",
+                "delete",
+            ]
+        );
+        assert!(widgets.iter().all(|widget| {
+            widget.uri.contains("ui://widget/catdesk-dashboard.html")
+                && widget
+                    .uri
+                    .contains(&format!("toolName={}", widget.tool_name))
+        }));
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace_root);
@@ -2831,6 +2973,45 @@ async fn post_mcp_inner(
     }
 
     if req.id.is_some() {
+        let response_succeeded = response_json
+            .as_ref()
+            .is_some_and(|response| response.get("error").is_none());
+        match req.method.as_str() {
+            "server/discover" => {
+                let _ = s
+                    .ui_events
+                    .send(ServerUiEvent::RecordBootstrapDiscoverResponse {
+                        flow_id: STATELESS_FLOW_ID.to_string(),
+                        success: response_succeeded,
+                    });
+            }
+            "tools/list" => {
+                let widgets = response_json
+                    .as_ref()
+                    .map(bootstrap_widgets_from_tools_list_response)
+                    .unwrap_or_default();
+                let _ = s
+                    .ui_events
+                    .send(ServerUiEvent::RecordBootstrapToolsListResponse {
+                        flow_id: STATELESS_FLOW_ID.to_string(),
+                        success: response_succeeded,
+                        widgets,
+                    });
+            }
+            "resources/read" => {
+                if let Some(uri) = request_resource_uri(&body) {
+                    let _ = s
+                        .ui_events
+                        .send(ServerUiEvent::RecordBootstrapWidgetReadResponse {
+                            flow_id: STATELESS_FLOW_ID.to_string(),
+                            uri: uri.to_string(),
+                            success: response_succeeded,
+                        });
+                }
+            }
+            _ => {}
+        }
+
         let _ = s.ui_events.send(ServerUiEvent::RecordFlow {
             flow_id: STATELESS_FLOW_ID.to_string(),
             events: vec![request_flow_event.clone()],

--- a/src/state.rs
+++ b/src/state.rs
@@ -50,17 +50,18 @@ pub struct FlowBootstrapProgress {
     pub discover_complete: bool,
     pub tools_list_complete: bool,
     pub expected_widgets: Vec<FlowBootstrapWidget>,
-    pub loaded_widget_uris: HashSet<String>,
+    pub loaded_widget_tool_names: HashSet<String>,
 }
 
 impl FlowBootstrapProgress {
+    pub fn widgets_complete(&self) -> bool {
+        self.expected_widgets
+            .iter()
+            .all(|widget| self.loaded_widget_tool_names.contains(&widget.tool_name))
+    }
+
     pub fn is_complete(&self) -> bool {
-        self.discover_complete
-            && self.tools_list_complete
-            && self
-                .expected_widgets
-                .iter()
-                .all(|widget| self.loaded_widget_uris.contains(&widget.uri))
+        self.discover_complete && self.tools_list_complete && self.widgets_complete()
     }
 }
 
@@ -368,7 +369,7 @@ pub enum ServerUiEvent {
     },
     RecordBootstrapWidgetReadResponse {
         flow_id: String,
-        uri: String,
+        tool_name: String,
         success: bool,
     },
     RecordTurnUsage {
@@ -982,10 +983,10 @@ impl AppState {
             }
             ServerUiEvent::RecordBootstrapWidgetReadResponse {
                 flow_id,
-                uri,
+                tool_name,
                 success,
             } => {
-                self.record_bootstrap_widget_read_response(&flow_id, &uri, success);
+                self.record_bootstrap_widget_read_response(&flow_id, &tool_name, success);
             }
             ServerUiEvent::RecordTurnUsage {
                 flow_id,
@@ -1113,10 +1114,10 @@ impl AppState {
         if !success {
             return;
         }
-        let mut seen_uris = HashSet::new();
+        let mut seen_tool_names = HashSet::new();
         let widgets = widgets
             .into_iter()
-            .filter(|widget| seen_uris.insert(widget.uri.clone()))
+            .filter(|widget| seen_tool_names.insert(widget.tool_name.clone()))
             .collect();
         let progress = self
             .flow_bootstrap_progress
@@ -1124,13 +1125,16 @@ impl AppState {
             .or_default();
         progress.tools_list_complete = true;
         progress.expected_widgets = widgets;
+        progress
+            .loaded_widget_tool_names
+            .retain(|tool_name| seen_tool_names.contains(tool_name));
         self.sync_flow_bootstrap_progress(flow_id);
     }
 
     pub fn record_bootstrap_widget_read_response(
         &mut self,
         flow_id: &str,
-        uri: &str,
+        tool_name: &str,
         success: bool,
     ) {
         if !success {
@@ -1139,8 +1143,8 @@ impl AppState {
         self.flow_bootstrap_progress
             .entry(flow_id.to_string())
             .or_default()
-            .loaded_widget_uris
-            .insert(uri.to_string());
+            .loaded_widget_tool_names
+            .insert(tool_name.to_string());
         self.sync_flow_bootstrap_progress(flow_id);
     }
 
@@ -1881,7 +1885,7 @@ toolCallCount = 0
         for widget in &widgets {
             let event = format!("resources/read:{}", widget.tool_name);
             app.record_flow("stateless", &[event.clone()], FlowDirection::Forward);
-            app.record_bootstrap_widget_read_response("stateless", &widget.uri, true);
+            app.record_bootstrap_widget_read_response("stateless", &widget.tool_name, true);
             app.record_flow("stateless", &[event], FlowDirection::Backward);
         }
 
@@ -1889,7 +1893,7 @@ toolCallCount = 0
         assert!(flow.bootstrap_status_active);
         assert!(flow.bootstrap_progress.is_complete());
         assert_eq!(flow.bootstrap_progress.expected_widgets, widgets);
-        assert_eq!(flow.bootstrap_progress.loaded_widget_uris.len(), 10);
+        assert_eq!(flow.bootstrap_progress.loaded_widget_tool_names.len(), 10);
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace);
@@ -1902,7 +1906,7 @@ toolCallCount = 0
         record_successful_bootstrap_handshake(&mut app, widgets.clone());
 
         for widget in widgets.iter().rev() {
-            app.record_bootstrap_widget_read_response("stateless", &widget.uri, true);
+            app.record_bootstrap_widget_read_response("stateless", &widget.tool_name, true);
         }
 
         let flow = app.flows.first().expect("missing flow");
@@ -1945,7 +1949,7 @@ toolCallCount = 0
         let widget = bootstrap_widget("read");
         record_successful_bootstrap_handshake(&mut app, vec![widget.clone()]);
 
-        app.record_bootstrap_widget_read_response("stateless", &widget.uri, false);
+        app.record_bootstrap_widget_read_response("stateless", &widget.tool_name, false);
         assert!(
             !app.flows
                 .first()
@@ -1954,7 +1958,7 @@ toolCallCount = 0
                 .is_complete()
         );
 
-        app.record_bootstrap_widget_read_response("stateless", &widget.uri, true);
+        app.record_bootstrap_widget_read_response("stateless", &widget.tool_name, true);
         assert!(
             app.flows
                 .first()
@@ -1962,6 +1966,65 @@ toolCallCount = 0
                 .bootstrap_progress
                 .is_complete()
         );
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn widget_completion_uses_tool_name_identity_even_if_widget_uri_changes() {
+        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-tool-name");
+        let mut widget = bootstrap_widget("read");
+        widget.uri = "ui://widget/catdesk-dashboard.html?widgetRevision=2&tokenStatsLayout=right&toolName=read".to_string();
+        record_successful_bootstrap_handshake(&mut app, vec![widget]);
+
+        app.record_bootstrap_widget_read_response("stateless", "read", true);
+
+        let flow = app.flows.first().expect("missing flow");
+        assert!(flow.bootstrap_progress.is_complete());
+        assert!(
+            flow.bootstrap_progress
+                .loaded_widget_tool_names
+                .contains("read")
+        );
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn different_tool_name_does_not_complete_expected_widget() {
+        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-wrong-tool");
+        let widget = bootstrap_widget("read");
+        record_successful_bootstrap_handshake(&mut app, vec![widget]);
+
+        app.record_bootstrap_widget_read_response("stateless", "search", true);
+
+        let flow = app.flows.first().expect("missing flow");
+        assert!(!flow.bootstrap_progress.is_complete());
+        assert!(
+            flow.bootstrap_progress
+                .loaded_widget_tool_names
+                .contains("search")
+        );
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn repeated_tools_list_drops_loaded_tools_that_are_no_longer_expected() {
+        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-refresh-tools");
+        let widgets = ["read", "search"].map(bootstrap_widget).to_vec();
+        record_successful_bootstrap_handshake(&mut app, widgets);
+        app.record_bootstrap_widget_read_response("stateless", "search", true);
+
+        app.record_bootstrap_tools_list_response("stateless", true, vec![bootstrap_widget("read")]);
+
+        let flow = app.flows.first().expect("missing flow");
+        assert_eq!(flow.bootstrap_progress.expected_widgets.len(), 1);
+        assert!(flow.bootstrap_progress.loaded_widget_tool_names.is_empty());
+        assert!(!flow.bootstrap_progress.is_complete());
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace);

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,6 @@
 use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
 use serde::{Deserialize, Serialize};
-use std::collections::{BTreeMap, HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::fs::{self, OpenOptions};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -30,8 +30,7 @@ pub struct FlowLane {
     pub events: Vec<String>,
     pub turn_usage: Option<UsageTotals>,
     pub bootstrap_status_active: bool,
-    pub bootstrap_completed_steps: usize,
-    pub bootstrap_pending_steps: VecDeque<usize>,
+    pub bootstrap_progress: FlowBootstrapProgress,
     pub bootstrap_status_close_deadline_ms: Option<u128>,
     pub anim_queue: VecDeque<FlowAnimSegment>,
     pub last_direction: FlowDirection,
@@ -39,10 +38,30 @@ pub struct FlowLane {
     pub closing_step_ms: u64,
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct FlowBootstrapWidget {
+    pub uri: String,
+    pub tool_name: String,
+    pub label: String,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct FlowBootstrapProgress {
-    pub completed_steps: usize,
-    pub pending_steps: VecDeque<usize>,
+    pub discover_complete: bool,
+    pub tools_list_complete: bool,
+    pub expected_widgets: Vec<FlowBootstrapWidget>,
+    pub loaded_widget_uris: HashSet<String>,
+}
+
+impl FlowBootstrapProgress {
+    pub fn is_complete(&self) -> bool {
+        self.discover_complete
+            && self.tools_list_complete
+            && self
+                .expected_widgets
+                .iter()
+                .all(|widget| self.loaded_widget_uris.contains(&widget.uri))
+    }
 }
 
 const APP_CONFIG_DIR_NAME: &str = ".catdesk";
@@ -338,6 +357,20 @@ pub enum ServerUiEvent {
         events: Vec<String>,
         direction: FlowDirection,
     },
+    RecordBootstrapDiscoverResponse {
+        flow_id: String,
+        success: bool,
+    },
+    RecordBootstrapToolsListResponse {
+        flow_id: String,
+        success: bool,
+        widgets: Vec<FlowBootstrapWidget>,
+    },
+    RecordBootstrapWidgetReadResponse {
+        flow_id: String,
+        uri: String,
+        success: bool,
+    },
     RecordTurnUsage {
         flow_id: String,
         tool_input_tokens: u64,
@@ -369,87 +402,6 @@ pub struct FlowAnimSegment {
     pub start_cells: usize,
     pub end_cells: usize,
 }
-
-#[derive(Clone, Copy)]
-pub struct FlowBootstrapStep {
-    pub event: &'static str,
-    pub label: &'static str,
-}
-
-#[derive(Clone, Copy)]
-pub struct FlowBootstrapPhase {
-    pub title: &'static str,
-    pub steps: &'static [FlowBootstrapStep],
-}
-
-const FLOW_BOOTSTRAP_PHASE_1_STEPS: &[FlowBootstrapStep] = &[
-    FlowBootstrapStep {
-        event: "server/discover",
-        label: "discover",
-    },
-    FlowBootstrapStep {
-        event: "tools/list",
-        label: "tools/list",
-    },
-];
-
-const FLOW_BOOTSTRAP_PHASE_2_STEPS: &[FlowBootstrapStep] = &[
-    FlowBootstrapStep {
-        event: "server/discover",
-        label: "discover",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:run_command",
-        label: "run_command",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:start_command",
-        label: "start_command",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:poll_command",
-        label: "poll_command",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:cancel_command",
-        label: "cancel_command",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:catdesk_instruction",
-        label: "instruction",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:read",
-        label: "read",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:search",
-        label: "search",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:write",
-        label: "write",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:edit",
-        label: "edit",
-    },
-    FlowBootstrapStep {
-        event: "resources/read:delete",
-        label: "delete",
-    },
-];
-
-pub const FLOW_BOOTSTRAP_PHASES: &[FlowBootstrapPhase] = &[
-    FlowBootstrapPhase {
-        title: "Connecting",
-        steps: FLOW_BOOTSTRAP_PHASE_1_STEPS,
-    },
-    FlowBootstrapPhase {
-        title: "Loading widgets",
-        steps: FLOW_BOOTSTRAP_PHASE_2_STEPS,
-    },
-];
 
 /// Which MCP backends to enable.
 #[derive(Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -818,86 +770,16 @@ fn enqueue_flow_segment(
     }
 }
 
-fn flow_bootstrap_step(index: usize, mode: ShowDetailMode) -> Option<&'static FlowBootstrapStep> {
-    let mut offset = 0;
-    let phases_to_check = if mode == ShowDetailMode::Disable {
-        1
-    } else {
-        FLOW_BOOTSTRAP_PHASES.len()
-    };
-    for phase in &FLOW_BOOTSTRAP_PHASES[..phases_to_check] {
-        let end = offset + phase.steps.len();
-        if index < end {
-            return phase.steps.get(index - offset);
-        }
-        offset = end;
-    }
-    None
-}
-
-pub fn flow_bootstrap_steps_total(mode: ShowDetailMode) -> usize {
-    let phases_to_check = if mode == ShowDetailMode::Disable {
-        1
-    } else {
-        FLOW_BOOTSTRAP_PHASES.len()
-    };
-    FLOW_BOOTSTRAP_PHASES[..phases_to_check]
-        .iter()
-        .map(|phase| phase.steps.len())
-        .sum()
-}
-
 fn events_start_bootstrap_status(events: &[String]) -> bool {
     events.iter().any(|event| event == "server/discover")
 }
 
 fn is_bootstrap_status_event(event: &str) -> bool {
-    FLOW_BOOTSTRAP_PHASES
-        .iter()
-        .flat_map(|phase| phase.steps)
-        .any(|step| step.event == event)
+    event == "server/discover" || event == "tools/list" || event.starts_with("resources/read:")
 }
 
 fn events_are_bootstrap_status_events(events: &[String]) -> bool {
     events.iter().all(|event| is_bootstrap_status_event(event))
-}
-
-fn advance_bootstrap_progress(
-    completed_steps: &mut usize,
-    pending_steps: &mut VecDeque<usize>,
-    events: &[String],
-    direction: FlowDirection,
-    mode: ShowDetailMode,
-) {
-    match direction {
-        FlowDirection::Forward => {
-            for event in events {
-                let next_index = completed_steps.saturating_add(pending_steps.len());
-                let Some(step) = flow_bootstrap_step(next_index, mode) else {
-                    break;
-                };
-                if step.event != event {
-                    continue;
-                }
-                pending_steps.push_back(next_index);
-            }
-        }
-        FlowDirection::Backward => {
-            for event in events {
-                let Some(pending_index) = pending_steps.front().copied() else {
-                    break;
-                };
-                let Some(step) = flow_bootstrap_step(pending_index, mode) else {
-                    pending_steps.clear();
-                    break;
-                };
-                if step.event == event {
-                    pending_steps.pop_front();
-                    *completed_steps = pending_index + 1;
-                }
-            }
-        }
-    }
 }
 
 impl AppState {
@@ -1088,6 +970,23 @@ impl AppState {
             } => {
                 self.record_flow(&flow_id, &events, direction);
             }
+            ServerUiEvent::RecordBootstrapDiscoverResponse { flow_id, success } => {
+                self.record_bootstrap_discover_response(&flow_id, success);
+            }
+            ServerUiEvent::RecordBootstrapToolsListResponse {
+                flow_id,
+                success,
+                widgets,
+            } => {
+                self.record_bootstrap_tools_list_response(&flow_id, success, widgets);
+            }
+            ServerUiEvent::RecordBootstrapWidgetReadResponse {
+                flow_id,
+                uri,
+                success,
+            } => {
+                self.record_bootstrap_widget_read_response(&flow_id, &uri, success);
+            }
             ServerUiEvent::RecordTurnUsage {
                 flow_id,
                 tool_input_tokens,
@@ -1114,11 +1013,6 @@ impl AppState {
         self.last_remote_activity_ms = Some(now_ms);
         self.remote_connected = true;
         let step_ms = derive_flow_step_ms();
-        let mut bootstrap = self
-            .flow_bootstrap_progress
-            .get(flow_id)
-            .cloned()
-            .unwrap_or_default();
         let starts_bootstrap_status = events_start_bootstrap_status(events);
         let only_bootstrap_status_events = events_are_bootstrap_status_events(events);
         let starts_tool_call = direction == FlowDirection::Forward
@@ -1130,6 +1024,12 @@ impl AppState {
                 flow.turn_usage = None;
             }
             if starts_bootstrap_status {
+                if !flow.bootstrap_status_active {
+                    let progress = FlowBootstrapProgress::default();
+                    self.flow_bootstrap_progress
+                        .insert(flow_id.to_string(), progress.clone());
+                    flow.bootstrap_progress = progress;
+                }
                 flow.bootstrap_status_active = true;
             } else if flow.bootstrap_status_active && !only_bootstrap_status_events {
                 flow.bootstrap_status_active = false;
@@ -1140,19 +1040,11 @@ impl AppState {
                 let drop_n = flow.events.len() - 12;
                 flow.events.drain(0..drop_n);
             }
-            flow.bootstrap_completed_steps = bootstrap.completed_steps;
-            flow.bootstrap_pending_steps = bootstrap.pending_steps.clone();
-            advance_bootstrap_progress(
-                &mut flow.bootstrap_completed_steps,
-                &mut flow.bootstrap_pending_steps,
-                events,
-                direction,
-                self.show_detail_mode,
-            );
-            bootstrap.completed_steps = flow.bootstrap_completed_steps;
-            bootstrap.pending_steps = flow.bootstrap_pending_steps.clone();
-            self.flow_bootstrap_progress
-                .insert(flow_id.to_string(), bootstrap);
+            flow.bootstrap_progress = self
+                .flow_bootstrap_progress
+                .get(flow_id)
+                .cloned()
+                .unwrap_or_default();
             flow.closing_started_ms = None;
             flow.closing_step_ms = 0;
             flow.bootstrap_status_close_deadline_ms = None;
@@ -1162,6 +1054,11 @@ impl AppState {
             return;
         }
 
+        let bootstrap_progress = self
+            .flow_bootstrap_progress
+            .entry(flow_id.to_string())
+            .or_default()
+            .clone();
         let mut trimmed = events.to_vec();
         if trimmed.len() > 12 {
             trimmed = trimmed[trimmed.len() - 12..].to_vec();
@@ -1174,8 +1071,7 @@ impl AppState {
                 events: trimmed,
                 turn_usage: None,
                 bootstrap_status_active: starts_bootstrap_status,
-                bootstrap_completed_steps: bootstrap.completed_steps,
-                bootstrap_pending_steps: bootstrap.pending_steps.clone(),
+                bootstrap_progress,
                 bootstrap_status_close_deadline_ms: None,
                 anim_queue: VecDeque::new(),
                 last_direction: direction,
@@ -1184,19 +1080,68 @@ impl AppState {
             },
         );
         if let Some(flow) = self.flows.first_mut() {
-            advance_bootstrap_progress(
-                &mut flow.bootstrap_completed_steps,
-                &mut flow.bootstrap_pending_steps,
-                events,
-                direction,
-                self.show_detail_mode,
-            );
-            bootstrap.completed_steps = flow.bootstrap_completed_steps;
-            bootstrap.pending_steps = flow.bootstrap_pending_steps.clone();
-            self.flow_bootstrap_progress
-                .insert(flow_id.to_string(), bootstrap);
             enqueue_flow_segment(&mut flow.anim_queue, direction, now_ms, step_ms);
         }
+    }
+
+    fn sync_flow_bootstrap_progress(&mut self, flow_id: &str) {
+        let Some(progress) = self.flow_bootstrap_progress.get(flow_id).cloned() else {
+            return;
+        };
+        if let Some(flow) = self.flows.iter_mut().find(|flow| flow.flow_id == flow_id) {
+            flow.bootstrap_progress = progress;
+        }
+    }
+
+    pub fn record_bootstrap_discover_response(&mut self, flow_id: &str, success: bool) {
+        if !success {
+            return;
+        }
+        self.flow_bootstrap_progress
+            .entry(flow_id.to_string())
+            .or_default()
+            .discover_complete = true;
+        self.sync_flow_bootstrap_progress(flow_id);
+    }
+
+    pub fn record_bootstrap_tools_list_response(
+        &mut self,
+        flow_id: &str,
+        success: bool,
+        widgets: Vec<FlowBootstrapWidget>,
+    ) {
+        if !success {
+            return;
+        }
+        let mut seen_uris = HashSet::new();
+        let widgets = widgets
+            .into_iter()
+            .filter(|widget| seen_uris.insert(widget.uri.clone()))
+            .collect();
+        let progress = self
+            .flow_bootstrap_progress
+            .entry(flow_id.to_string())
+            .or_default();
+        progress.tools_list_complete = true;
+        progress.expected_widgets = widgets;
+        self.sync_flow_bootstrap_progress(flow_id);
+    }
+
+    pub fn record_bootstrap_widget_read_response(
+        &mut self,
+        flow_id: &str,
+        uri: &str,
+        success: bool,
+    ) {
+        if !success {
+            return;
+        }
+        self.flow_bootstrap_progress
+            .entry(flow_id.to_string())
+            .or_default()
+            .loaded_widget_uris
+            .insert(uri.to_string());
+        self.sync_flow_bootstrap_progress(flow_id);
     }
 
     pub fn record_flow_turn_usage(
@@ -1235,7 +1180,6 @@ impl AppState {
 
     pub fn prune_closed_flows(&mut self) {
         let now_ms = now_unix_millis();
-        let bootstrap_steps_total = flow_bootstrap_steps_total(self.show_detail_mode);
 
         for flow in &mut self.flows {
             prune_finished_segments(&mut flow.anim_queue, now_ms);
@@ -1243,8 +1187,7 @@ impl AppState {
                 flow.bootstrap_status_close_deadline_ms = None;
                 continue;
             }
-            let bootstrap_complete = flow.bootstrap_completed_steps >= bootstrap_steps_total
-                && flow.bootstrap_pending_steps.is_empty();
+            let bootstrap_complete = flow.bootstrap_progress.is_complete();
             if flow.closing_started_ms.is_none() && bootstrap_complete {
                 if flow.anim_queue.is_empty() {
                     match flow.bootstrap_status_close_deadline_ms {
@@ -1787,8 +1730,7 @@ toolCallCount = 0
 
         let flow = app.flows.first().expect("missing flow");
         assert!(!flow.bootstrap_status_active);
-        assert_eq!(flow.bootstrap_completed_steps, 0);
-        assert!(flow.bootstrap_pending_steps.is_empty());
+        assert_eq!(flow.bootstrap_progress, FlowBootstrapProgress::default());
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace);
@@ -1844,8 +1786,7 @@ toolCallCount = 0
 
         let flow = app.flows.first().expect("missing flow");
         assert!(flow.bootstrap_status_active);
-        assert_eq!(flow.bootstrap_completed_steps, 0);
-        assert_eq!(flow.bootstrap_pending_steps.front(), Some(&0));
+        assert_eq!(flow.bootstrap_progress, FlowBootstrapProgress::default());
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace);
@@ -1878,89 +1819,163 @@ toolCallCount = 0
         let _ = std::fs::remove_dir_all(workspace);
     }
 
+    fn bootstrap_widget(tool_name: &str) -> FlowBootstrapWidget {
+        FlowBootstrapWidget {
+            uri: format!("ui://widget/catdesk-dashboard.html?toolName={tool_name}"),
+            tool_name: tool_name.to_string(),
+            label: if tool_name == "catdesk_instruction" {
+                "instruction".to_string()
+            } else {
+                tool_name.to_string()
+            },
+        }
+    }
+
+    fn record_successful_bootstrap_handshake(
+        app: &mut AppState,
+        widgets: Vec<FlowBootstrapWidget>,
+    ) {
+        app.record_flow(
+            "stateless",
+            &["server/discover".to_string()],
+            FlowDirection::Forward,
+        );
+        app.record_bootstrap_discover_response("stateless", true);
+        app.record_flow(
+            "stateless",
+            &["server/discover".to_string()],
+            FlowDirection::Backward,
+        );
+        app.record_flow(
+            "stateless",
+            &["tools/list".to_string()],
+            FlowDirection::Forward,
+        );
+        app.record_bootstrap_tools_list_response("stateless", true, widgets);
+        app.record_flow(
+            "stateless",
+            &["tools/list".to_string()],
+            FlowDirection::Backward,
+        );
+    }
+
     #[test]
-    fn record_flow_bootstrap_tracks_modern_tool_and_widget_loading_sequence() {
+    fn bootstrap_completes_from_runtime_advertised_widgets() {
         let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-widgets");
+        let widgets = [
+            "run_command",
+            "start_command",
+            "poll_command",
+            "cancel_command",
+            "catdesk_instruction",
+            "read",
+            "search",
+            "write",
+            "edit",
+            "delete",
+        ]
+        .map(bootstrap_widget)
+        .to_vec();
+        record_successful_bootstrap_handshake(&mut app, widgets.clone());
 
-        let sequence = [
-            // Phase 1: Connecting
-            ("server/discover", FlowDirection::Forward),
-            ("server/discover", FlowDirection::Backward),
-            ("tools/list", FlowDirection::Forward),
-            ("tools/list", FlowDirection::Backward),
-            // Phase 2: Loading widgets
-            ("server/discover", FlowDirection::Forward),
-            ("server/discover", FlowDirection::Backward),
-            ("resources/read:run_command", FlowDirection::Forward),
-            ("resources/read:run_command", FlowDirection::Backward),
-            ("resources/read:start_command", FlowDirection::Forward),
-            ("resources/read:start_command", FlowDirection::Backward),
-            ("resources/read:poll_command", FlowDirection::Forward),
-            ("resources/read:poll_command", FlowDirection::Backward),
-            ("resources/read:cancel_command", FlowDirection::Forward),
-            ("resources/read:cancel_command", FlowDirection::Backward),
-            ("resources/read:catdesk_instruction", FlowDirection::Forward),
-            (
-                "resources/read:catdesk_instruction",
-                FlowDirection::Backward,
-            ),
-            ("resources/read:read", FlowDirection::Forward),
-            ("resources/read:read", FlowDirection::Backward),
-            ("resources/read:search", FlowDirection::Forward),
-            ("resources/read:search", FlowDirection::Backward),
-            ("resources/read:write", FlowDirection::Forward),
-            ("resources/read:write", FlowDirection::Backward),
-            ("resources/read:edit", FlowDirection::Forward),
-            ("resources/read:edit", FlowDirection::Backward),
-            ("resources/read:delete", FlowDirection::Forward),
-            ("resources/read:delete", FlowDirection::Backward),
-        ];
-
-        for (event, direction) in sequence {
-            app.record_flow("stateless", &[event.to_string()], direction);
+        for widget in &widgets {
+            let event = format!("resources/read:{}", widget.tool_name);
+            app.record_flow("stateless", &[event.clone()], FlowDirection::Forward);
+            app.record_bootstrap_widget_read_response("stateless", &widget.uri, true);
+            app.record_flow("stateless", &[event], FlowDirection::Backward);
         }
 
         let flow = app.flows.first().expect("missing flow");
         assert!(flow.bootstrap_status_active);
-        let phase_step_counts: Vec<usize> = FLOW_BOOTSTRAP_PHASES
-            .iter()
-            .map(|phase| phase.steps.len())
-            .collect();
-        assert_eq!(phase_step_counts, vec![2, 11]);
-        assert_eq!(flow_bootstrap_steps_total(ShowDetailMode::Expanded), 13);
-        assert_eq!(flow_bootstrap_steps_total(ShowDetailMode::Collapsed), 13);
-        assert_eq!(flow_bootstrap_steps_total(ShowDetailMode::Disable), 2);
-        assert_eq!(
-            flow.bootstrap_completed_steps,
-            flow_bootstrap_steps_total(ShowDetailMode::Expanded)
-        );
-        assert!(flow.bootstrap_pending_steps.is_empty());
+        assert!(flow.bootstrap_progress.is_complete());
+        assert_eq!(flow.bootstrap_progress.expected_widgets, widgets);
+        assert_eq!(flow.bootstrap_progress.loaded_widget_uris.len(), 10);
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace);
     }
 
     #[test]
-    fn record_flow_disable_bootstrap_completes_after_discover_and_tools_list() {
-        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-disable");
-        app.show_detail_mode = ShowDetailMode::Disable;
+    fn bootstrap_widget_reads_can_complete_out_of_order() {
+        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-out-of-order");
+        let widgets = ["read", "search", "edit"].map(bootstrap_widget).to_vec();
+        record_successful_bootstrap_handshake(&mut app, widgets.clone());
 
-        let sequence = [
-            ("server/discover", FlowDirection::Forward),
-            ("server/discover", FlowDirection::Backward),
-            ("tools/list", FlowDirection::Forward),
-            ("tools/list", FlowDirection::Backward),
-        ];
-
-        for (event, direction) in sequence {
-            app.record_flow("stateless", &[event.to_string()], direction);
+        for widget in widgets.iter().rev() {
+            app.record_bootstrap_widget_read_response("stateless", &widget.uri, true);
         }
 
         let flow = app.flows.first().expect("missing flow");
+        assert!(flow.bootstrap_progress.is_complete());
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn bootstrap_ignores_optional_rediscover_without_resetting_widgets() {
+        let (mut app, workspace, config_path) =
+            test_app("catdesk-flow-bootstrap-optional-rediscover");
+        let widgets = ["run_command", "read"].map(bootstrap_widget).to_vec();
+        record_successful_bootstrap_handshake(&mut app, widgets.clone());
+
+        app.record_flow(
+            "stateless",
+            &["server/discover".to_string()],
+            FlowDirection::Forward,
+        );
+        app.record_bootstrap_discover_response("stateless", true);
+        app.record_flow(
+            "stateless",
+            &["server/discover".to_string()],
+            FlowDirection::Backward,
+        );
+
+        let flow = app.flows.first().expect("missing flow");
+        assert_eq!(flow.bootstrap_progress.expected_widgets, widgets);
+        assert!(flow.bootstrap_progress.tools_list_complete);
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn failed_widget_read_requires_successful_retry() {
+        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-read-retry");
+        let widget = bootstrap_widget("read");
+        record_successful_bootstrap_handshake(&mut app, vec![widget.clone()]);
+
+        app.record_bootstrap_widget_read_response("stateless", &widget.uri, false);
+        assert!(
+            !app.flows
+                .first()
+                .expect("missing flow")
+                .bootstrap_progress
+                .is_complete()
+        );
+
+        app.record_bootstrap_widget_read_response("stateless", &widget.uri, true);
+        assert!(
+            app.flows
+                .first()
+                .expect("missing flow")
+                .bootstrap_progress
+                .is_complete()
+        );
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir_all(workspace);
+    }
+
+    #[test]
+    fn bootstrap_without_advertised_widgets_completes_after_tools_list() {
+        let (mut app, workspace, config_path) = test_app("catdesk-flow-bootstrap-no-widgets");
+        record_successful_bootstrap_handshake(&mut app, Vec::new());
+
+        let flow = app.flows.first().expect("missing flow");
         assert!(flow.bootstrap_status_active);
-        assert_eq!(flow.bootstrap_completed_steps, 2);
-        assert!(flow.bootstrap_pending_steps.is_empty());
-        assert_eq!(flow_bootstrap_steps_total(ShowDetailMode::Disable), 2);
+        assert!(flow.bootstrap_progress.is_complete());
+        assert!(flow.bootstrap_progress.expected_widgets.is_empty());
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir_all(workspace);


### PR DESCRIPTION
Fixes #7.

Track bootstrap completion using the widgets advertised by tools/list and successful resources/read responses, instead of relying on a fixed request sequence.

Also handles widget resources loading out of order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bootstrap progress now reflects widgets discovered and loaded at runtime.
  - Widget loading supports varying numbers of widgets and out-of-order responses.
  - Progress indicators provide clearer phase and step status during startup.

- **Bug Fixes**
  - Bootstrap completion and visibility are tracked accurately, including when no widgets are available.
  - Failed widget responses no longer count as successfully loaded.
  - Refreshed widget lists and changing resource details are handled correctly.
  - Widget resource URI validation is now consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->