### PR TITLE
feat: make the macOS Terminal profile opt-in on first launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ If you don't want to use CatDesk, here are some similar projects you can try:
 
    By default, CatDesk listens on port `3200`. You can override it with `PORT`. The workspace root defaults to the current working directory and can be overridden with `WORKSPACE_ROOT`.
 
-   On macOS Terminal.app, CatDesk manages a dedicated `CatDesk` Terminal profile automatically. If the current Terminal tab is not already using that profile, CatDesk applies it, closes any temporary helper window, and asks you to run the same command again in that tab. It only starts immediately when the current tab is already using `CatDesk`. Set `CATDESK_SKIP_MACOS_TERMINAL_PROFILE=1` if you want to keep the current Terminal session untouched.
+   On the first launch from macOS Terminal.app, CatDesk asks whether you want to use its dedicated `CatDesk` Terminal profile and saves that choice to `~/.catdesk/config.toml`. If enabled and the current tab is not already using that profile, CatDesk applies it, closes any temporary helper window, and asks you to run the same command again in that tab. Subsequent launches reuse the saved preference. Set `CATDESK_SKIP_MACOS_TERMINAL_PROFILE=1` to temporarily keep the current Terminal session untouched regardless of the saved preference.
 
 3. Wait for the TUI to show the MCP Server URL.
 

--- a/src/macos_terminal.rs
+++ b/src/macos_terminal.rs
@@ -67,8 +67,8 @@ unsafe extern "C" {
 }
 
 #[cfg(target_os = "macos")]
-pub fn maybe_relaunch_in_terminal_profile() -> Result<LaunchAction, String> {
-    if !should_manage_terminal_launch() {
+pub fn maybe_relaunch_in_terminal_profile(profile_enabled: bool) -> Result<LaunchAction, String> {
+    if !profile_enabled || !should_manage_terminal_launch() {
         return Ok(LaunchAction::Continue);
     }
 
@@ -125,8 +125,18 @@ pub fn maybe_relaunch_in_terminal_profile() -> Result<LaunchAction, String> {
 }
 
 #[cfg(not(target_os = "macos"))]
-pub fn maybe_relaunch_in_terminal_profile() -> Result<LaunchAction, String> {
+pub fn maybe_relaunch_in_terminal_profile(_profile_enabled: bool) -> Result<LaunchAction, String> {
     Ok(LaunchAction::Continue)
+}
+
+#[cfg(target_os = "macos")]
+pub fn should_prompt_for_terminal_profile() -> bool {
+    should_manage_terminal_launch()
+}
+
+#[cfg(not(target_os = "macos"))]
+pub fn should_prompt_for_terminal_profile() -> bool {
+    false
 }
 
 #[cfg(target_os = "macos")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -34,8 +34,9 @@ use ratatui::{
 use state::{
     AppState, FLOW_ANIM_CELLS, FlowAnimKind, FlowAnimSegment, FlowDirection, FlowLane,
     GPT_5_6_AND_EARLIER_USAGE_BUCKET, LogEntry, Mode, ServerUiEvent, SharedState, ShowDetailMode,
-    ToolMode, UsageTotals, app_config_path, flow_anim_lit_count, load_ngrok_authtoken,
-    load_ngrok_domain, save_ngrok_authtoken, save_ngrok_domain, user_home_dir,
+    ToolMode, UsageTotals, app_config_path, flow_anim_lit_count, load_macos_terminal_profile,
+    load_ngrok_authtoken, load_ngrok_domain, save_macos_terminal_profile, save_ngrok_authtoken,
+    save_ngrok_domain, user_home_dir,
 };
 use std::collections::HashMap;
 use std::io::{Write, stdout};
@@ -1144,6 +1145,42 @@ fn drain_server_ui_events(app: &mut AppState, ui_events: &mut UnboundedReceiver<
 
 // ── Main ────────────────────────────────────────────────────
 
+fn parse_terminal_profile_choice(input: &str) -> Option<bool> {
+    match input.trim().to_ascii_lowercase().as_str() {
+        "" | "y" | "yes" => Some(true),
+        "n" | "no" => Some(false),
+        _ => None,
+    }
+}
+
+fn prompt_macos_terminal_profile() -> std::io::Result<bool> {
+    loop {
+        println!("CatDesk can apply its Terminal.app profile for the best TUI appearance.");
+        print!("Use the CatDesk Terminal.app profile? [Y/n]: ");
+        std::io::stdout().flush()?;
+
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if let Some(enabled) = parse_terminal_profile_choice(&input) {
+            return Ok(enabled);
+        }
+        eprintln!("Please answer y/yes or n/no.");
+    }
+}
+
+fn macos_terminal_profile_enabled() -> std::io::Result<bool> {
+    if !macos_terminal::should_prompt_for_terminal_profile() {
+        return Ok(true);
+    }
+    if let Some(enabled) = load_macos_terminal_profile()? {
+        return Ok(enabled);
+    }
+
+    let enabled = prompt_macos_terminal_profile()?;
+    save_macos_terminal_profile(enabled)?;
+    Ok(enabled)
+}
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(target_os = "linux")]
@@ -1152,7 +1189,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         unreachable!("Landlock helper returned after exec");
     }
 
-    match macos_terminal::maybe_relaunch_in_terminal_profile() {
+    let terminal_profile_enabled = macos_terminal_profile_enabled()?;
+    match macos_terminal::maybe_relaunch_in_terminal_profile(terminal_profile_enabled) {
         Ok(macos_terminal::LaunchAction::Continue) => {}
         #[cfg(target_os = "macos")]
         Ok(macos_terminal::LaunchAction::ExitAfterProfileBootstrap) => {
@@ -2283,10 +2321,20 @@ mod tests {
     use super::{
         LogView, draw_chatgpt_connector_refresh_notice, draw_tui_header, export_logs_to_dir,
         key_is_clipboard_paste, mask_mcp_path_in_log, normalize_ngrok_authtoken_input,
-        text_input_key_is_cancel, wrap_log_message,
+        parse_terminal_profile_choice, text_input_key_is_cancel, wrap_log_message,
     };
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend, layout::Rect};
+
+    #[test]
+    fn parses_terminal_profile_choice() {
+        assert_eq!(parse_terminal_profile_choice(""), Some(true));
+        assert_eq!(parse_terminal_profile_choice(" y "), Some(true));
+        assert_eq!(parse_terminal_profile_choice("YES"), Some(true));
+        assert_eq!(parse_terminal_profile_choice("n"), Some(false));
+        assert_eq!(parse_terminal_profile_choice(" No "), Some(false));
+        assert_eq!(parse_terminal_profile_choice("maybe"), None);
+    }
 
     #[test]
     fn normalizes_plain_ngrok_token() {

--- a/src/state.rs
+++ b/src/state.rs
@@ -219,6 +219,8 @@ pub struct AppConfig {
     #[serde(default)]
     pub show_detail_mode: ShowDetailMode,
     #[serde(default)]
+    pub macos_terminal_profile: Option<bool>,
+    #[serde(default)]
     pub partner_binagotchy_seed: Option<String>,
     #[serde(default)]
     pub set_catdesk_as_co_author: bool,
@@ -241,6 +243,7 @@ impl Default for AppConfig {
             agents_path_mode: AgentsPathMode::Default,
             token_stats_layout: TokenStatsLayout::Right,
             show_detail_mode: ShowDetailMode::Expanded,
+            macos_terminal_profile: None,
             partner_binagotchy_seed: None,
             set_catdesk_as_co_author: false,
             theme: theme::DEFAULT_THEME_ID.to_string(),
@@ -614,6 +617,18 @@ pub fn save_show_detail_mode(mode: ShowDetailMode) -> std::io::Result<PathBuf> {
     let path = app_config_path()?;
     let mut config = AppConfig::load_from_path(&path)?;
     config.show_detail_mode = mode;
+    config.save_to_path(&path)?;
+    Ok(path)
+}
+
+pub fn load_macos_terminal_profile() -> std::io::Result<Option<bool>> {
+    Ok(load_app_config()?.macos_terminal_profile)
+}
+
+pub fn save_macos_terminal_profile(enabled: bool) -> std::io::Result<PathBuf> {
+    let path = app_config_path()?;
+    let mut config = AppConfig::load_from_path(&path)?;
+    config.macos_terminal_profile = Some(enabled);
     config.save_to_path(&path)?;
     Ok(path)
 }
@@ -1611,6 +1626,30 @@ toolCallCount = 1
 
         let saved = AppConfig::load_from_path(&config_path).expect("load config");
         assert!(matches!(saved.show_detail_mode, ShowDetailMode::Collapsed));
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir(workspace);
+    }
+
+    #[test]
+    fn app_config_round_trips_macos_terminal_profile_preference() {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let workspace =
+            std::env::temp_dir().join(format!("catdesk-config-terminal-profile-{unique}"));
+        std::fs::create_dir_all(&workspace).expect("create temp config dir");
+        let config_path = workspace.join(APP_CONFIG_FILE_NAME);
+
+        let config = AppConfig {
+            macos_terminal_profile: Some(false),
+            ..AppConfig::default()
+        };
+        config.save_to_path(&config_path).expect("save config");
+
+        let saved = AppConfig::load_from_path(&config_path).expect("load config");
+        assert_eq!(saved.macos_terminal_profile, Some(false));
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir(workspace);


### PR DESCRIPTION
## Summary

Make the dedicated CatDesk Terminal.app profile opt-in instead of applying it automatically.

On the first launch from macOS Terminal.app, CatDesk now asks whether the user wants to use the CatDesk profile and persists that choice in `~/.catdesk/config.toml`.

## Behavior

- First launch from macOS Terminal.app prompts:
  - `Y` / `yes` / Enter: use the CatDesk Terminal profile
  - `N` / `no`: keep the current Terminal profile
- The choice is saved as `macosTerminalProfile` in `~/.catdesk/config.toml`.
- Subsequent launches reuse the saved preference without prompting again.
- Other terminals and non-macOS platforms are unaffected.
- `CATDESK_SKIP_MACOS_TERMINAL_PROFILE` remains supported as a temporary override and does not overwrite the saved preference.
- Existing configs remain compatible because the new field defaults to an unset preference.

## Why

Applying a Terminal profile automatically on first launch can be unexpected, especially for users with customized Terminal.app profiles.

This keeps the existing CatDesk profile available while giving the user an explicit choice before CatDesk changes the current Terminal tab.

## Tests

- `cargo fmt -- --check` ✅
- `git diff --check` ✅
- `cargo test --release parses_terminal_profile_choice` ✅
- `cargo test --release app_config_round_trips_macos_terminal_profile_preference` ✅
- `cargo build --release` ✅

`cargo test --release` currently reports 203 passed / 6 failed locally. The six failures are existing `change_tracking` path-normalization tests on macOS where absolute temporary paths are returned instead of the expected relative paths; this PR does not modify `change_tracking`.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a first-launch prompt on macOS to enable CatDesk’s dedicated Terminal profile.
  * Saved the Terminal profile preference for future launches.
  * Added an environment variable option to temporarily bypass the dedicated profile.
  * Updated macOS Terminal quickstart instructions.

* **Bug Fixes**
  * Improved handling when the dedicated Terminal profile is disabled or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->