### PR TITLE
feat: add ChatGPT reasoning profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,8 @@ If you don't want to use CatDesk, here are some similar projects you can try:
 
    When CatDesk starts, choose `Control Computer`, `Control Browser`, or `Both`. Press `l` on the mode selection screen to switch between English and Traditional Chinese; the preference is saved in `~/.catdesk/config.toml`. If browser control is enabled, select a supported Chromium browser. On macOS, CatDesk detects standard browser app bundles in `/Applications` and `~/Applications` in addition to binaries available on `PATH`.
 
+   In `Settings`, you can manually sync CatDesk's ChatGPT reasoning profile with the level you selected in ChatGPT: `Low`, `Medium`, `High`, `Extra High`, or `PRO`. The profile only changes CatDesk's tool-workflow guidance; it does not change the ChatGPT model or reasoning setting. `High` is the default, and the choice is saved in `~/.catdesk/config.toml`. `Extra High` and `PRO` are marked as Pro-oriented profiles but are not account-gated by CatDesk.
+
    On first launch, CatDesk will ask you to enter your **ngrok authtoken** and **ngrok static domain** (e.g. `my-app.ngrok-free.dev`). You can get both from the [ngrok dashboard](https://dashboard.ngrok.com/get-started/setup). These are saved to `~/.catdesk/config.toml` and reused on subsequent launches.
 
    By default, CatDesk listens on port `3200`. You can override it with `PORT`. The workspace root defaults to the current working directory and can be overridden with `WORKSPACE_ROOT`.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -112,6 +112,8 @@ ChatGPT Web + CatDesk
 
    CatDesk 啟動後，可以選擇 `Control Computer`、`Control Browser` 或 `Both`。在模式選擇畫面按 `l` 可以在 English 與繁體中文之間切換；語言偏好會儲存在 `~/.catdesk/config.toml`。如果啟用了瀏覽器控制，請選擇一個支援的 Chromium 瀏覽器。在 macOS 上，除了 `PATH` 中的 binary，CatDesk 也會偵測 `/Applications` 與 `~/Applications` 裡的標準瀏覽器 App bundle。
 
+   在 `Settings` 裡，也可以手動把 CatDesk 的 ChatGPT reasoning profile 與你在 ChatGPT 中選擇的推理等級同步：`Low`、`Medium`、`High`、`Extra High` 或 `PRO`。這個 profile 只會調整 CatDesk 提供給模型的工具工作流程指引，不會切換 ChatGPT 模型或推理設定。預設為 `High`，選擇會儲存在 `~/.catdesk/config.toml`。`Extra High` 與 `PRO` 會標示為偏向 Pro 使用的 profile，但 CatDesk 不會檢查或限制帳號方案。
+
    第一次啟動時，CatDesk 會要求你輸入 **ngrok authtoken** 和 **ngrok static domain**（例如 `my-app.ngrok-free.dev`）。這兩項都可以從 [ngrok dashboard](https://dashboard.ngrok.com/get-started/setup) 取得，並會儲存在 `~/.catdesk/config.toml`，之後啟動時自動重用。
 
    CatDesk 預設監聽 `3200` port。可以用 `PORT` 覆寫。Workspace root 預設為你啟動 CatDesk 時所在的目錄，也可以用 `WORKSPACE_ROOT` 覆寫。

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,8 +33,8 @@ use ratatui::{
 };
 use state::{
     AppState, FLOW_ANIM_CELLS, FlowAnimKind, FlowAnimSegment, FlowDirection, FlowLane,
-    GPT_5_6_AND_EARLIER_USAGE_BUCKET, LogEntry, Mode, ServerUiEvent, SharedState, ShowDetailMode,
-    ToolMode, UiLanguage, UsageTotals, app_config_path, flow_anim_lit_count,
+    GPT_5_6_AND_EARLIER_USAGE_BUCKET, LogEntry, Mode, ReasoningProfile, ServerUiEvent, SharedState,
+    ShowDetailMode, ToolMode, UiLanguage, UsageTotals, app_config_path, flow_anim_lit_count,
     load_macos_terminal_profile, load_ngrok_authtoken, load_ngrok_domain,
     save_macos_terminal_profile, save_ngrok_authtoken, save_ngrok_domain, user_home_dir,
 };
@@ -2415,8 +2415,8 @@ fn render_toast(f: &mut Frame, palette: theme::Palette, msg: &str, pos: (u16, u1
 mod tests {
     use super::state::{ToolMode, UiLanguage};
     use super::{
-        LogView, draw_chatgpt_connector_refresh_notice, draw_mode_select, draw_tui_header,
-        export_logs_to_dir, key_is_clipboard_paste, mask_mcp_path_in_log,
+        LogView, draw_chatgpt_connector_refresh_notice, draw_mode_select, draw_settings,
+        draw_tui_header, export_logs_to_dir, key_is_clipboard_paste, mask_mcp_path_in_log,
         normalize_ngrok_authtoken_input, parse_terminal_profile_choice, text_input_key_is_cancel,
         wrap_log_message,
     };
@@ -2518,6 +2518,50 @@ mod tests {
         assert!(!text_input_key_is_cancel(KeyCode::Char('q')));
         assert!(!text_input_key_is_cancel(KeyCode::Char('Q')));
         assert!(text_input_key_is_cancel(KeyCode::Esc));
+    }
+
+    #[test]
+    fn settings_render_reasoning_profiles_and_pro_hint() {
+        let mut terminal = Terminal::new(TestBackend::new(110, 80)).expect("create test terminal");
+        let theme = super::theme::all()[0];
+        let selected_row = super::theme::all().len()
+            + super::ToolMode::all().len()
+            + super::ShowDetailMode::all().len()
+            + super::ReasoningProfile::all().len()
+            - 1;
+
+        terminal
+            .draw(|frame| {
+                draw_settings(
+                    frame,
+                    &theme,
+                    super::ToolMode::MultiTools,
+                    super::ShowDetailMode::Expanded,
+                    super::ReasoningProfile::Pro,
+                    false,
+                    "secret-slug",
+                    Some("example.ngrok.app"),
+                    &super::UsageTotals::default(),
+                    selected_row,
+                    false,
+                )
+            })
+            .expect("draw settings");
+
+        let buffer = terminal.backend().buffer();
+        let text = (0..buffer.area.height)
+            .map(|row| {
+                (0..buffer.area.width)
+                    .map(|column| buffer[(column, row)].symbol())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(text.contains("ChatGPT reasoning profile"));
+        assert!(text.contains("PRO"));
+        assert!(text.contains("[Pro]"));
+        assert!(text.contains("[current]"));
     }
 
     #[test]
@@ -2795,18 +2839,25 @@ async fn run_settings(
     let themes = theme::all();
     let tool_modes = ToolMode::all();
     let show_detail_modes = ShowDetailMode::all();
+    let reasoning_profiles = ReasoningProfile::all();
     let mut confirm_reset_token_billing = false;
     let mut selected_row = {
         let app = state.lock().await;
         themes.iter().position(|t| t.id == app.theme).unwrap_or(0)
     };
-    let total_rows = themes.len() + tool_modes.len() + show_detail_modes.len() + 1 + 3;
+    let total_rows = themes.len()
+        + tool_modes.len()
+        + show_detail_modes.len()
+        + reasoning_profiles.len()
+        + 1
+        + 3;
 
     loop {
         let (
             current_theme,
             current_tool_mode,
             current_show_detail_mode,
+            current_reasoning_profile,
             usage_totals,
             set_catdesk_as_co_author,
             mcp_slug,
@@ -2817,6 +2868,7 @@ async fn run_settings(
                 app.current_theme(),
                 app.tool_mode,
                 app.show_detail_mode,
+                app.reasoning_profile,
                 app.all_time_usage_totals(),
                 app.set_catdesk_as_co_author,
                 app.mcp_slug.clone(),
@@ -2829,6 +2881,7 @@ async fn run_settings(
                 current_theme,
                 current_tool_mode,
                 current_show_detail_mode,
+                current_reasoning_profile,
                 set_catdesk_as_co_author,
                 &mcp_slug,
                 ngrok_domain.as_deref(),
@@ -2870,6 +2923,9 @@ async fn run_settings(
                             let tool_mode_end = tool_mode_start + tool_modes.len();
                             let detail_mode_start = tool_mode_end;
                             let detail_mode_end = detail_mode_start + show_detail_modes.len();
+                            let reasoning_profile_start = detail_mode_end;
+                            let reasoning_profile_end =
+                                reasoning_profile_start + reasoning_profiles.len();
 
                             if selected_row < tool_mode_end {
                                 let picked = tool_modes[selected_row - tool_mode_start];
@@ -2888,7 +2944,18 @@ async fn run_settings(
                                     );
                                     app.persist_state_with_log();
                                 }
-                            } else if selected_row == detail_mode_end {
+                            } else if selected_row < reasoning_profile_end {
+                                let picked =
+                                    reasoning_profiles[selected_row - reasoning_profile_start];
+                                if app.reasoning_profile != picked {
+                                    app.reasoning_profile = picked;
+                                    app.log(
+                                        "INFO",
+                                        format!("Reasoning profile: {}", picked.label()),
+                                    );
+                                    app.persist_state_with_log();
+                                }
+                            } else if selected_row == reasoning_profile_end {
                                 app.set_catdesk_as_co_author = !app.set_catdesk_as_co_author;
                                 let enabled = app.set_catdesk_as_co_author;
                                 app.log(
@@ -2899,13 +2966,13 @@ async fn run_settings(
                                     ),
                                 );
                                 app.persist_state_with_log();
-                            } else if selected_row == detail_mode_end + 1 {
+                            } else if selected_row == reasoning_profile_end + 1 {
                                 // Keep existing slug, do nothing
-                            } else if selected_row == detail_mode_end + 2 {
+                            } else if selected_row == reasoning_profile_end + 2 {
                                 app.regenerate_mcp_slug();
                                 app.log("INFO", "Generated new random MCP slug".into());
                                 app.persist_state_with_log();
-                            } else if selected_row == detail_mode_end + 3 {
+                            } else if selected_row == reasoning_profile_end + 3 {
                                 let current_domain = app.ngrok_domain.clone().unwrap_or_default();
                                 drop(app);
                                 if let Some(new_domain) = run_prompt(terminal, "Enter ngrok static domain (with/without https://, empty to clear):", &current_domain).await? {
@@ -2949,6 +3016,7 @@ fn draw_settings(
     current_theme: &theme::ThemeDef,
     current_tool_mode: ToolMode,
     current_show_detail_mode: ShowDetailMode,
+    current_reasoning_profile: ReasoningProfile,
     set_catdesk_as_co_author: bool,
     mcp_slug: &str,
     ngrok_domain: Option<&str>,
@@ -2959,6 +3027,7 @@ fn draw_settings(
     let themes = theme::all();
     let tool_modes = ToolMode::all();
     let show_detail_modes = ShowDetailMode::all();
+    let reasoning_profiles = ReasoningProfile::all();
     let palette = current_theme.palette;
     let area = f.area();
     let chunks = Layout::default()
@@ -3096,7 +3165,59 @@ fn draw_settings(
         )]));
     }
 
-    let co_author_row = themes.len() + tool_modes.len() + show_detail_modes.len();
+    lines.push(Line::from(""));
+    lines.push(Line::from(vec![Span::styled(
+        "  ChatGPT reasoning profile",
+        Style::default()
+            .fg(palette.title_fg)
+            .add_modifier(Modifier::BOLD),
+    )]));
+    lines.push(Line::from(vec![Span::styled(
+        "     Manual tool-workflow hint only; keep it in sync with ChatGPT yourself.",
+        Style::default().fg(palette.muted_fg),
+    )]));
+    for (idx, profile) in reasoning_profiles.iter().enumerate() {
+        let row_idx = themes.len() + tool_modes.len() + show_detail_modes.len() + idx;
+        let selected = row_idx == selected_row;
+        let marker = if selected { ">" } else { " " };
+        let name_style = if selected {
+            Style::default()
+                .fg(palette.key_fg)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(palette.primary_fg)
+        };
+        lines.push(Line::from(""));
+        if selected {
+            selected_line_idx = lines.len();
+        }
+        let mut spans = vec![Span::styled(
+            format!(" {} [{}] {}", marker, row_idx + 1, profile.label()),
+            name_style,
+        )];
+        if profile.pro_tier_hint() {
+            spans.push(Span::styled(
+                "  [Pro]",
+                Style::default().fg(palette.warning_fg),
+            ));
+        }
+        if *profile == current_reasoning_profile {
+            spans.push(Span::styled(
+                "  [current]",
+                Style::default()
+                    .fg(palette.secondary_fg)
+                    .add_modifier(Modifier::BOLD),
+            ));
+        }
+        lines.push(Line::from(spans));
+        lines.push(Line::from(vec![Span::styled(
+            format!("     {}", profile.description()),
+            Style::default().fg(palette.muted_fg),
+        )]));
+    }
+
+    let co_author_row =
+        themes.len() + tool_modes.len() + show_detail_modes.len() + reasoning_profiles.len();
     let co_author_selected = co_author_row == selected_row;
     let co_author_marker = if co_author_selected { ">" } else { " " };
     let co_author_name_style = if co_author_selected {
@@ -3296,7 +3417,7 @@ fn draw_settings(
 
     let body = Paragraph::new(lines).scroll((scroll_y, 0)).block(
         Block::default()
-            .title(" Theme, Tool Mode & Billing ")
+            .title(" Theme, Tool Mode, Reasoning & Billing ")
             .borders(Borders::ALL)
             .border_type(palette.border_type)
             .border_style(Style::default().fg(palette.border_fg)),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -17,8 +17,8 @@ use crate::command_jobs::{
 use crate::devtools::DevtoolsBridge;
 use crate::mascot;
 use crate::state::{
-    AgentsPathMode, Mode, ShowDetailMode, TokenStatsLayout, ToolMode, app_config_path,
-    load_app_config, user_home_dir,
+    AgentsPathMode, Mode, ReasoningProfile, ShowDetailMode, TokenStatsLayout, ToolMode,
+    app_config_path, load_app_config, user_home_dir,
 };
 use crate::workspace_tools;
 
@@ -2075,6 +2075,14 @@ fn widget_path_strings(path: &Path) -> (String, String) {
     )
 }
 
+fn reasoning_profile_instruction(profile: ReasoningProfile) -> String {
+    format!(
+        "CatDesk reasoning profile is a user-selected tool-workflow hint and does not change the ChatGPT model or reasoning setting. Current profile: {}. {}",
+        profile.label(),
+        profile.workflow_instruction()
+    )
+}
+
 fn catdesk_instruction_text(
     workspace_root: &str,
     mode: Mode,
@@ -2137,6 +2145,10 @@ Always specify the branch explicitly when using `git push`."#
                 .to_string(),
         );
     }
+
+    let reasoning_profile = load_app_config()?.reasoning_profile;
+    lines.push("".to_string());
+    lines.push(reasoning_profile_instruction(reasoning_profile));
 
     if let Some(agents_text) = preferred_agents_text(workspace_root)? {
         lines.push("".to_string());
@@ -3599,6 +3611,15 @@ fn handle_delete_path(req: &JsonRpcRequest, workspace_root: &str) -> JsonRpcResp
 mod tests {
     use super::*;
     use uuid::Uuid;
+
+    #[test]
+    fn pro_reasoning_profile_instruction_is_explicitly_advisory() {
+        let text = reasoning_profile_instruction(ReasoningProfile::Pro);
+        assert!(text.contains("does not change the ChatGPT model or reasoning setting"));
+        assert!(text.contains("Current profile: PRO"));
+        assert!(text.contains("long-horizon, repo-wide workflows"));
+        assert!(text.contains("avoid unnecessary user handoffs"));
+    }
 
     fn resources_list_request() -> JsonRpcRequest {
         JsonRpcRequest {

--- a/src/state.rs
+++ b/src/state.rs
@@ -230,6 +230,78 @@ impl UiLanguage {
     }
 }
 
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningProfile {
+    Low,
+    Medium,
+    #[default]
+    High,
+    ExtraHigh,
+    Pro,
+}
+
+impl ReasoningProfile {
+    pub fn all() -> &'static [Self] {
+        const PROFILES: [ReasoningProfile; 5] = [
+            ReasoningProfile::Low,
+            ReasoningProfile::Medium,
+            ReasoningProfile::High,
+            ReasoningProfile::ExtraHigh,
+            ReasoningProfile::Pro,
+        ];
+        &PROFILES
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            Self::Low => "Low",
+            Self::Medium => "Medium",
+            Self::High => "High",
+            Self::ExtraHigh => "Extra High",
+            Self::Pro => "PRO",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            Self::Low => "Keep CatDesk workflows narrow, short, and quick to validate.",
+            Self::Medium => "Balance context gathering, tool batching, and validation.",
+            Self::High => {
+                "Use broader context and complete multi-step coding tasks before reporting."
+            }
+            Self::ExtraHigh => {
+                "Explore related code proactively and validate changes more broadly."
+            }
+            Self::Pro => "Use long-horizon, repo-wide workflows with minimal unnecessary handoffs.",
+        }
+    }
+
+    pub fn workflow_instruction(self) -> &'static str {
+        match self {
+            Self::Low => {
+                "Keep CatDesk tool workflows narrow and short. Prefer targeted reads and searches, small edits, and quick validation."
+            }
+            Self::Medium => {
+                "Balance context gathering, batching closely related reads and searches, and validation before finishing."
+            }
+            Self::High => {
+                "Gather broader context before editing, batch related reads and searches, and complete multi-step coding tasks before reporting back."
+            }
+            Self::ExtraHigh => {
+                "Explore related code and dependencies proactively, batch independent context gathering, and run both targeted and broader validation when useful."
+            }
+            Self::Pro => {
+                "Use long-horizon, repo-wide workflows: proactively trace cross-file dependencies, batch tool calls where practical, avoid unnecessary user handoffs, and finish implementation plus validation end-to-end when safe."
+            }
+        }
+    }
+
+    pub fn pro_tier_hint(self) -> bool {
+        matches!(self, Self::ExtraHigh | Self::Pro)
+    }
+}
+
 #[derive(Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AppConfig {
@@ -246,6 +318,8 @@ pub struct AppConfig {
     pub token_stats_layout: TokenStatsLayout,
     #[serde(default)]
     pub show_detail_mode: ShowDetailMode,
+    #[serde(default)]
+    pub reasoning_profile: ReasoningProfile,
     #[serde(default)]
     pub macos_terminal_profile: Option<bool>,
     #[serde(default)]
@@ -273,6 +347,7 @@ impl Default for AppConfig {
             agents_path_mode: AgentsPathMode::Default,
             token_stats_layout: TokenStatsLayout::Right,
             show_detail_mode: ShowDetailMode::Expanded,
+            reasoning_profile: ReasoningProfile::High,
             macos_terminal_profile: None,
             ui_language: UiLanguage::English,
             partner_binagotchy_seed: None,
@@ -511,6 +586,7 @@ pub struct AppState {
     pub tool_mode: ToolMode,
     pub show_detail_mode: ShowDetailMode,
     pub ui_language: UiLanguage,
+    pub reasoning_profile: ReasoningProfile,
     pub mcp_slug: String,
     pub ngrok_domain: Option<String>,
     pub is_returning_user: bool,
@@ -882,6 +958,7 @@ impl AppState {
             tool_mode: config.tool_mode,
             show_detail_mode: config.show_detail_mode,
             ui_language: config.ui_language,
+            reasoning_profile: config.reasoning_profile,
             mcp_slug,
             ngrok_domain: config.ngrok_domain.clone(),
             is_returning_user,
@@ -959,6 +1036,7 @@ impl AppState {
         config.tool_mode = self.tool_mode;
         config.show_detail_mode = self.show_detail_mode;
         config.ui_language = self.ui_language;
+        config.reasoning_profile = self.reasoning_profile;
         config.usage_by_model = self.usage_by_model.clone();
         config.selected_browser = self.selected_browser.clone();
         Ok(config.normalized())
@@ -1683,6 +1761,30 @@ toolCallCount = 1
 
         let saved = AppConfig::load_from_path(&config_path).expect("load config");
         assert!(matches!(saved.show_detail_mode, ShowDetailMode::Collapsed));
+
+        let _ = std::fs::remove_file(config_path);
+        let _ = std::fs::remove_dir(workspace);
+    }
+
+    #[test]
+    fn app_config_round_trips_reasoning_profile() {
+        let unique = SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let workspace =
+            std::env::temp_dir().join(format!("catdesk-config-reasoning-profile-{unique}"));
+        std::fs::create_dir_all(&workspace).expect("create temp config dir");
+        let config_path = workspace.join(APP_CONFIG_FILE_NAME);
+
+        let config = AppConfig {
+            reasoning_profile: ReasoningProfile::Pro,
+            ..AppConfig::default()
+        };
+        config.save_to_path(&config_path).expect("save config");
+
+        let saved = AppConfig::load_from_path(&config_path).expect("load config");
+        assert_eq!(saved.reasoning_profile, ReasoningProfile::Pro);
 
         let _ = std::fs::remove_file(config_path);
         let _ = std::fs::remove_dir(workspace);


### PR DESCRIPTION
## Summary

Add configurable ChatGPT reasoning profiles so CatDesk can adapt its tool-workflow guidance to the reasoning level selected by the user in ChatGPT.

Available profiles:

- Low
- Medium
- High
- Extra High
- PRO

`High` is the default.

## How it works

The selected profile is saved in `~/.catdesk/config.toml` and included in `catdesk_instruction`.

CatDesk does **not** change the ChatGPT model or its actual reasoning setting. The profile is only a user-selected workflow hint that changes how CatDesk encourages ChatGPT to use tools.

Higher profiles progressively encourage things such as:

- gathering broader repository context
- batching related reads and searches
- tracing cross-file dependencies
- completing multi-step work before reporting back
- running broader validation
- reducing unnecessary user handoffs
- finishing implementation and validation end-to-end when appropriate

`Extra High` and `PRO` are visually marked as Pro-oriented profiles, but CatDesk does not perform subscription or account checks.

## UI

A new **ChatGPT reasoning profile** section is available in Settings.

The current profile is marked with `[current]`, while `Extra High` and `PRO` display a `[Pro]` hint.

## Documentation

The reasoning profile behavior is documented in both:

- `README.md`
- `README.zh-TW.md`

## Why

ChatGPT offers different reasoning levels depending on the selected model and plan.

CatDesk cannot control those settings directly, but it can adjust its own tool-use guidance to better match the level the user selected in ChatGPT.

This makes higher-reasoning modes more useful for longer, repository-wide coding workflows while keeping lower profiles suitable for smaller and faster tasks.

## Validation

- Reasoning profile tests ✅
- Traditional Chinese configuration test ✅
- English / Traditional Chinese mode-selection test ✅
- `cargo build --release` ✅
- `git diff --check` ✅

Full `cargo test --release` result:

- 217 tests
- 211 passed
- 6 failed

The six failures are the existing macOS `change_tracking` absolute-path tests and are unrelated to this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ChatGPT reasoning profile setting with Low, Medium, High, Extra High, and PRO options.
  * Settings now displays profile descriptions, the selected profile, and PRO-tier guidance.
  * The selected profile defaults to High and persists across sessions.
  * The profile guides workflow instructions without changing the model or ChatGPT reasoning configuration.

* **Documentation**
  * Updated English and Traditional Chinese quickstart documentation with profile options, defaults, persistence details, and account-plan behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->