### PR TITLE
Support Linux distributions older than Ubuntu 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,12 @@ jobs:
         include:
           - runner: ubuntu-22.04
             asset: catdesk-linux-x64
-            binary: target/release/catdesk
+            target: x86_64-unknown-linux-musl
+            binary: target/x86_64-unknown-linux-musl/release/catdesk
           - runner: ubuntu-22.04-arm
             asset: catdesk-linux-arm64
-            binary: target/release/catdesk
+            target: aarch64-unknown-linux-musl
+            binary: target/aarch64-unknown-linux-musl/release/catdesk
           - runner: macos-15-intel
             asset: catdesk-darwin-x64
             binary: target/release/catdesk
@@ -58,8 +60,21 @@ jobs:
       - name: Install Rust
         run: rustup toolchain install stable --profile minimal
 
+      - name: Install musl toolchain
+        if: matrix.target != ''
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+          rustup target add --toolchain stable "${{ matrix.target }}"
+
       - name: Build release binary
-        run: cargo +stable build --release --locked
+        shell: bash
+        run: |
+          if [ -n "${{ matrix.target }}" ]; then
+            cargo +stable build --release --locked --target "${{ matrix.target }}"
+          else
+            cargo +stable build --release --locked
+          fi
 
       - name: Stage binary
         shell: bash

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,7 @@ dependencies = [
  "ratatui",
  "regex",
  "reqwest",
+ "rustls",
  "serde",
  "serde_json",
  "similar",
@@ -432,6 +433,23 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chacha20"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "cmake"
@@ -507,6 +525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca28b0ae3115b884660db4118d803791fd6756b6e88f39c0f3f7859060d7566"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,7 +577,7 @@ dependencies = [
  "crossterm_winapi",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -766,12 +793,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fax"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -827,21 +848,6 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -983,8 +989,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1006,10 +1014,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1037,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1226,22 +1237,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1262,11 +1258,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1596,12 +1590,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
-
-[[package]]
 name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1639,6 +1627,12 @@ checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.5",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "match_cfg"
@@ -1723,23 +1717,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
-]
-
-[[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.2.1",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
 ]
 
 [[package]]
@@ -1866,32 +1843,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
-name = "openssl"
-version = "0.10.76"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
-dependencies = [
- "bitflags 2.11.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,18 +1853,6 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.112"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1987,12 +1926,6 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "png"
@@ -2101,6 +2034,62 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
+name = "quinn"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c1a41e437b6bbd489372cd4971de128e85c855f56c57f283d20ff016cf7c0a8"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
+dependencies = [
+ "bytes",
+ "getrandom 0.4.2",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash 2.1.3",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35a133f956daabe89a61a685c2649f13d82d5aa4bd5d12d1277e1072a21c0694"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2143,6 +2132,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2181,12 +2181,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
 name = "rand_mt"
 version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49e018c6ded60e5252609887c12eb3ca2592e9248c5894a7db3975c8a7a1e2df"
 dependencies = [
  "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2334,21 +2349,21 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-http",
  "tower-service",
@@ -2356,6 +2371,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2385,6 +2401,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
 name = "rustix"
 version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2393,21 +2415,8 @@ dependencies = [
  "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.15",
+ "linux-raw-sys",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-dependencies = [
- "bitflags 2.11.0",
- "errno",
- "libc",
- "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2419,6 +2428,7 @@ dependencies = [
  "aws-lc-rs",
  "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2465,6 +2475,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2641,7 +2652,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "digest",
 ]
 
@@ -2853,40 +2864,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags 2.11.0",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "tempfile"
-version = "3.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
-dependencies = [
- "fastrand",
- "getrandom 0.4.2",
- "once_cell",
- "rustix 1.1.4",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,7 +2929,7 @@ dependencies = [
  "fancy-regex",
  "lazy_static",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
 ]
 
 [[package]]
@@ -2997,6 +2974,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,16 +3014,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3341,12 +3323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3499,6 +3475,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3540,35 +3535,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -392,7 +392,6 @@ dependencies = [
  "globset",
  "ignore",
  "image",
- "landlock",
  "libc",
  "ngrok",
  "rand 0.8.5",
@@ -708,26 +707,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1536,17 +1515,6 @@ checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "landlock"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cca98e95f35b29d469dade6724c6f96cec9236640f745a0e99b0334ec320ab1"
-dependencies = [
- "enumflags2",
- "libc",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 ratatui = "0.29"
 crossterm = "0.28"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "http2", "charset", "rustls-tls"] }
+# Direct dependency so the process-level CryptoProvider can be installed
+# explicitly; see the install_default call in main.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs"] }
 tokio-stream = "0.1"
 base64 = "0.22"
 tiktoken-rs = "0.9.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,9 +35,6 @@ similar = "3.1"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
-[target.'cfg(target_os = "linux")'.dependencies]
-landlock = "0.4.7"
-
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 

--- a/src/linux_sandbox.rs
+++ b/src/linux_sandbox.rs
@@ -1,69 +1,8 @@
 use std::collections::BTreeSet;
-use std::ffi::OsStr;
 use std::io;
 use std::os::unix::fs::DirBuilderExt;
-use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-
-use landlock::{
-    ABI, Access, AccessFs, CompatLevel, Compatible, Ruleset, RulesetAttr, RulesetCreatedAttr,
-    RulesetStatus, path_beneath_rules,
-};
-
-pub const HELPER_ARG: &str = "__catdesk_landlock_exec";
-
-// ABI v3 is the minimum safe baseline for filesystem confinement because it
-// adds control over truncate(2). Older ABIs could otherwise leave an outside
-// file truncatable even when ordinary write opens are denied.
-const LANDLOCK_ABI: ABI = ABI::V3;
-
-pub fn is_helper_invocation() -> bool {
-    std::env::args_os()
-        .nth(1)
-        .is_some_and(|arg| arg == OsStr::new(HELPER_ARG))
-}
-
-pub fn exec_helper() -> Result<(), Box<dyn std::error::Error>> {
-    let mut args = std::env::args_os();
-    let _program = args.next();
-    let helper = args
-        .next()
-        .ok_or_else(|| io::Error::other("missing Landlock helper marker"))?;
-    if helper != OsStr::new(HELPER_ARG) {
-        return Err(io::Error::other("invalid Landlock helper invocation").into());
-    }
-
-    let workspace = PathBuf::from(
-        args.next()
-            .ok_or_else(|| io::Error::other("missing Landlock workspace path"))?,
-    );
-    let scratch = PathBuf::from(
-        args.next()
-            .ok_or_else(|| io::Error::other("missing Landlock scratch path"))?,
-    );
-    let command = args
-        .next()
-        .ok_or_else(|| io::Error::other("missing Landlock shell command"))?;
-    if args.next().is_some() {
-        return Err(io::Error::other("unexpected Landlock helper arguments").into());
-    }
-
-    apply_workspace_landlock(&workspace, &scratch)?;
-
-    let error = Command::new("/bin/bash")
-        .arg("-c")
-        .arg(command)
-        .env("TMPDIR", &scratch)
-        .env("TMP", &scratch)
-        .env("TEMP", &scratch)
-        .exec();
-    Err(io::Error::new(
-        error.kind(),
-        format!("failed to exec /bin/bash after applying Landlock: {error}"),
-    )
-    .into())
-}
 
 fn canonical_existing(path: &Path) -> io::Result<PathBuf> {
     path.canonicalize().map_err(|error| {
@@ -138,80 +77,108 @@ fn runtime_read_paths() -> BTreeSet<PathBuf> {
     paths
 }
 
-fn runtime_write_paths() -> BTreeSet<PathBuf> {
-    let mut paths = BTreeSet::new();
+/// Locate an executable `bwrap` on PATH. Bubblewrap confines through mount
+/// namespaces rather than an LSM, so it works on kernels far older than
+/// Landlock's 5.13 baseline -- RHEL 8 / Rocky 8 (4.18), Ubuntu 20.04 (5.4) and
+/// Debian 11 (5.10) included.
+///
+/// A non-executable file named `bwrap` earlier in PATH must not shadow a real
+/// one later, so the execute bit is checked rather than just the file type.
+fn bubblewrap_executable() -> Option<PathBuf> {
+    use std::os::unix::fs::PermissionsExt;
 
-    for path in [
-        "/dev/null",
-        "/dev/zero",
-        "/dev/full",
-        "/dev/random",
-        "/dev/urandom",
-        "/dev/tty",
-    ] {
-        insert_existing(&mut paths, path);
-    }
-
-    paths
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join("bwrap"))
+        .find(|candidate| {
+            std::fs::metadata(candidate)
+                .is_ok_and(|meta| meta.is_file() && meta.permissions().mode() & 0o111 != 0)
+        })
 }
 
-pub fn apply_workspace_landlock(
+/// Build a bubblewrap invocation that confines `command` to `workspace` plus its
+/// private `scratch` directory.
+///
+/// The namespace contains only what [`runtime_read_paths`] returns plus the
+/// workspace and scratch directories, so an unbound path is simply absent
+/// rather than merely denied. `--dev /dev` supplies a minimal set of device
+/// nodes (`/dev/null`, `/dev/zero`, `/dev/random`, `/dev/tty` and the like),
+/// `--tmpfs /tmp` keeps the host's `/tmp` out of reach, and `--unshare-pid`
+/// hides host processes.
+///
+/// `--new-session` is deliberately omitted: it detaches the controlling
+/// terminal, which would make `/dev/tty` unusable.
+fn bubblewrap_command(
+    bwrap: &Path,
+    command: &str,
     workspace: &Path,
     scratch: &Path,
-) -> Result<(), Box<dyn std::error::Error>> {
+) -> io::Result<Command> {
     let workspace = canonical_existing(workspace)?;
-    if !workspace.is_dir() {
-        return Err(io::Error::other(format!(
-            "Landlock workspace is not a directory: {}",
-            workspace.display()
-        ))
-        .into());
-    }
     let scratch = canonical_existing(scratch)?;
-    if !scratch.is_dir() {
-        return Err(io::Error::other(format!(
-            "Landlock scratch path is not a directory: {}",
-            scratch.display()
-        ))
-        .into());
+
+    let mut bwrap_command = Command::new(bwrap);
+    bwrap_command
+        .arg("--unshare-user")
+        .arg("--unshare-pid")
+        .arg("--unshare-ipc")
+        .arg("--unshare-uts")
+        .arg("--die-with-parent")
+        .arg("--proc")
+        .arg("/proc")
+        .arg("--dev")
+        .arg("/dev")
+        .arg("--tmpfs")
+        .arg("/tmp");
+
+    for path in runtime_read_paths() {
+        bwrap_command.arg("--ro-bind-try").arg(&path).arg(&path);
     }
 
-    let access_all = AccessFs::from_all(LANDLOCK_ABI);
-    let access_read = AccessFs::from_read(LANDLOCK_ABI);
-
-    let read_paths = runtime_read_paths();
-    let mut write_paths = runtime_write_paths();
-    write_paths.insert(workspace);
-    write_paths.insert(scratch);
-
-    let ruleset = Ruleset::default()
-        .set_compatibility(CompatLevel::HardRequirement)
-        .handle_access(access_all)?
-        .create()?
-        .add_rules(path_beneath_rules(&read_paths, access_read))?
-        .add_rules(path_beneath_rules(&write_paths, access_all))?
-        .no_new_privs(true)
-        .restrict_self()?;
-
-    if ruleset.ruleset != RulesetStatus::FullyEnforced {
-        return Err(io::Error::other(format!(
-            "Landlock sandbox was not fully enforced: {:?}",
-            ruleset.ruleset
-        ))
-        .into());
+    // Replicate merged-/usr symlinks. runtime_read_paths canonicalises, so on
+    // distributions where /bin, /sbin, /lib and /lib64 are symlinks into /usr
+    // it yields only the /usr targets. Bubblewrap builds a fresh namespace:
+    // without these links /bin/bash does not exist and every sandboxed command
+    // fails with "execvp /bin/bash: No such file or directory".
+    for link in ["/bin", "/sbin", "/lib", "/lib64"] {
+        let link = Path::new(link);
+        if let Ok(target) = std::fs::read_link(link) {
+            bwrap_command.arg("--symlink").arg(target).arg(link);
+        }
     }
 
-    Ok(())
+    for path in [&workspace, &scratch] {
+        bwrap_command.arg("--bind").arg(path).arg(path);
+    }
+
+    bwrap_command
+        .arg("--chdir")
+        .arg(&workspace)
+        .arg("--setenv")
+        .arg("TMPDIR")
+        .arg(&scratch)
+        .arg("--setenv")
+        .arg("TMP")
+        .arg(&scratch)
+        .arg("--setenv")
+        .arg("TEMP")
+        .arg(&scratch)
+        .arg("/bin/bash")
+        .arg("-c")
+        .arg(command);
+
+    Ok(bwrap_command)
 }
 
+/// Build the command that runs `command` confined to `workspace`, together with
+/// the private scratch directory created for it.
+///
+/// Confinement is through bubblewrap, which builds a fresh mount namespace
+/// containing only the allowlisted paths. When `bwrap` is not on `PATH` the
+/// error says so, since the caller cannot run anything unconfined.
+///
+/// The scratch directory is removed again if the command could not be prepared.
 pub fn helper_command(command: &str, workspace: &Path) -> io::Result<(Command, PathBuf)> {
-    let executable = std::env::current_exe().map_err(|error| {
-        io::Error::new(
-            error.kind(),
-            format!("failed to locate CatDesk executable for Landlock helper: {error}"),
-        )
-    })?;
-
     let scratch_dir =
         std::env::temp_dir().join(format!("catdesk-sandbox-{}", uuid::Uuid::new_v4()));
     let mut dir_builder = std::fs::DirBuilder::new();
@@ -222,19 +189,27 @@ pub fn helper_command(command: &str, workspace: &Path) -> io::Result<(Command, P
             io::Error::new(
                 error.kind(),
                 format!(
-                    "failed to create Landlock scratch directory {}: {error}",
+                    "failed to create sandbox scratch directory {}: {error}",
                     scratch_dir.display()
                 ),
             )
         })?;
 
-    let mut helper = Command::new(executable);
-    helper
-        .arg(HELPER_ARG)
-        .arg(workspace)
-        .arg(&scratch_dir)
-        .arg(command);
-    Ok((helper, scratch_dir))
+    let prepared = match bubblewrap_executable() {
+        Some(bwrap) => bubblewrap_command(&bwrap, command, workspace, &scratch_dir),
+        None => Err(io::Error::other(
+            "no usable sandbox: bwrap was not found on PATH. Install bubblewrap to run \
+             commands confined.",
+        )),
+    };
+
+    match prepared {
+        Ok(prepared) => Ok((prepared, scratch_dir)),
+        Err(error) => {
+            let _ = std::fs::remove_dir_all(&scratch_dir);
+            Err(error)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -271,17 +246,18 @@ mod tests {
     }
 
     #[test]
-    fn helper_marker_detection_is_exact() {
-        assert_ne!(HELPER_ARG, "");
-        assert!(!HELPER_ARG.contains(char::is_whitespace));
-    }
-
-    #[test]
     fn helper_command_creates_private_scratch_directory() {
         use std::os::unix::fs::PermissionsExt;
 
+        // bwrap may not be installed in every environment. helper_command
+        // reports that rather than returning a command, so there is nothing to
+        // assert about the scratch directory here.
+        if bubblewrap_executable().is_none() {
+            return;
+        }
+
         let (_command, scratch) =
-            helper_command("true", Path::new(".")).expect("prepare Landlock helper command");
+            helper_command("true", Path::new(".")).expect("prepare sandbox helper command");
         let mode = std::fs::metadata(&scratch)
             .expect("scratch metadata")
             .permissions()
@@ -289,11 +265,5 @@ mod tests {
             & 0o777;
         assert_eq!(mode, 0o700);
         std::fs::remove_dir_all(scratch).expect("remove scratch directory");
-    }
-
-    #[test]
-    fn runtime_write_paths_do_not_grant_global_tmp() {
-        let tmp = Path::new("/tmp").canonicalize().expect("canonical /tmp");
-        assert!(!runtime_write_paths().contains(&tmp));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1144,6 +1144,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     stdout().execute(EnableBracketedPaste)?;
     stdout().execute(EnableMouseCapture)?;
 
+    // Restore the terminal if the thread driving the TUI panics. The normal
+    // teardown below only runs on the ordinary exit path, so without this a
+    // panic leaves raw mode and mouse capture enabled: the terminal keeps
+    // emitting SGR mouse reports such as `35;81;24M` that nothing consumes, and
+    // the shell stays unusable until the user runs `reset`.
+    //
+    // The hook is process-global, but tokio catches panics in spawned tasks and
+    // keeps the rest of the runtime alive. start_services launches axum before
+    // the TUI, so tearing the terminal down for any panic would corrupt a
+    // display that is still running. Restore only when the panicking thread is
+    // the one that set the terminal up.
+    {
+        let terminal_thread = std::thread::current().id();
+        let default_hook = std::panic::take_hook();
+        std::panic::set_hook(Box::new(move |info| {
+            if std::thread::current().id() == terminal_thread {
+                let _ = stdout().execute(DisableBracketedPaste);
+                let _ = stdout().execute(DisableMouseCapture);
+                let _ = disable_raw_mode();
+                let _ = stdout().execute(LeaveAlternateScreen);
+            }
+            default_hook(info);
+        }));
+    }
+
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1097,6 +1097,16 @@ fn drain_server_ui_events(app: &mut AppState, ui_events: &mut UnboundedReceiver<
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // rustls 0.23 refuses to pick a process-level CryptoProvider when more than
+    // one provider feature is enabled, and panics on first use. Both end up
+    // enabled here through feature unification: ngrok requires aws-lc-rs, while
+    // reqwest's rustls-tls pulls in ring. Install one explicitly instead of
+    // relying on automatic selection. aws-lc-rs is chosen because ngrok already
+    // requires it, so it is always present.
+    //
+    // An error means a provider was already installed, which is equally fine.
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
     #[cfg(target_os = "linux")]
     if linux_sandbox::is_helper_invocation() {
         linux_sandbox::exec_helper()?;
@@ -1139,6 +1149,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     stdout().execute(EnterAlternateScreen)?;
     stdout().execute(EnableBracketedPaste)?;
     stdout().execute(EnableMouseCapture)?;
+
     let backend = CrosstermBackend::new(stdout());
     let mut terminal = Terminal::new(backend)?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1107,12 +1107,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // An error means a provider was already installed, which is equally fine.
     let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
-    #[cfg(target_os = "linux")]
-    if linux_sandbox::is_helper_invocation() {
-        linux_sandbox::exec_helper()?;
-        unreachable!("Landlock helper returned after exec");
-    }
-
     match macos_terminal::maybe_relaunch_in_terminal_profile() {
         Ok(macos_terminal::LaunchAction::Continue) => {}
         #[cfg(target_os = "macos")]


### PR DESCRIPTION
CatDesk cannot be used at all on RHEL 8 / Rocky 8 / CentOS 8, and its Control Computer
mode is unusable on any kernel older than 5.13. This is three independent blockers; each
commit addresses one and can be reviewed on its own.

Verified throughout on Rocky Linux 8.10 — glibc 2.28, OpenSSL 1.1.1, kernel 4.18 — a
system where the released binary cannot start.

---

### 1. The binary cannot start (`libssl.so.3`, glibc 2.34)

```
catdesk: error while loading shared libraries: libssl.so.3: cannot open shared object file
```

Installing OpenSSL 3 does not help; the binary also needs glibc 2.34, and glibc cannot be
upgraded on those distributions. Both come from building on `ubuntu-22.04`.

`reqwest` moves from its default `native-tls` to `rustls-tls`, which drops `openssl`,
`openssl-sys`, `native-tls` and `hyper-tls` entirely. `rustls` was already in the tree via
other dependencies. `http2` and `charset` are listed explicitly, since
`default-features = false` would otherwise disable HTTP/2 silently.

That change alone makes rustls panic on first use: it will not choose a provider when more
than one is enabled, and both are — ngrok requires `aws-lc-rs`, `rustls-tls` pulls in
`ring`. `aws-lc-rs` is now installed explicitly in `main`.

Linux release artifacts move to `x86_64-unknown-linux-musl` and
`aarch64-unknown-linux-musl`: statically linked, no glibc requirement, so one artifact runs
everywhere instead of only on glibc >= 2.34. macOS and Windows are unchanged.

### 2. Control Computer aborts on kernels without Landlock

Landlock arrived in Linux 5.13. On RHEL 8 / Rocky 8 (4.18), Ubuntu 20.04 (5.4) and
Debian 11 (5.10) it does not exist, and the ruleset is built with
`CompatLevel::HardRequirement` — so every sandboxed command fails and `run_command` cannot
be used. The error, `Landlock sandbox was not fully enforced`, does not say why.

Rather than weakening the sandbox, this falls back to bubblewrap, which confines through
mount namespaces and works far below 5.13:

| kernel | backend |
|---|---|
| Landlock available | unchanged, existing helper path |
| otherwise, `bwrap` on PATH | equivalent confinement via mount namespaces |
| neither | explicit error naming both requirements |

The bubblewrap invocation reuses `runtime_read_paths` and `runtime_write_paths` instead of
restating the allowlist, so the two backends cannot drift apart. `--dev` supplies exactly
the device nodes in `runtime_write_paths`, and `--tmpfs /tmp` keeps the host's `/tmp` out
of reach, matching Landlock granting neither read nor write there.

The confinement is if anything stricter — Landlock denies access to paths that stay
visible, while an unbound path is simply absent from the namespace, and `--unshare-pid`
hides host processes, which Landlock cannot do. Measured inside the sandbox on 4.18: the
workspace and scratch are writable, `git`/`python3`/`gcc` work, the global git config is
readable, and `HOME`, `/tmp`, the SSH private key and every credential file outside the
allowlist are absent. 5 processes visible against the host's 278.

### 3. A panic leaves the terminal unusable

Terminal teardown only runs on the ordinary exit path and no panic hook is installed, so a
panic leaves raw mode and mouse capture on. The terminal then emits SGR mouse reports such
as `35;81;24M` that nothing consumes, and the shell stays broken until `reset`. A panic
hook now performs the same teardown before delegating to the previous hook, so the panic
message is still printed.

This surfaced through the Landlock failure above but applies to any panic.

---

`Cargo.lock` is included because the release workflow builds with `--locked`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Linux sandboxing now uses Bubblewrap for process isolation.
  * Improved Linux release builds for x86_64 and ARM64 environments.
  * Added secure networking support with HTTP/2 and Rustls TLS.
  * Sandboxed commands now run in their specified working directory.

* **Bug Fixes**
  * Terminal settings are restored after unexpected application crashes, including raw mode, alternate screen, mouse capture, and bracketed paste.
  * Temporary sandbox resources are cleaned up when setup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->