### PR TITLE
fix: keep change tracking paths workspace-relative

### DIFF
--- a/src/change_tracking/mod.rs
+++ b/src/change_tracking/mod.rs
@@ -70,9 +70,11 @@ pub(crate) struct ChangeSession {
 
 impl ChangeSession {
     pub(crate) fn begin(workspace_root: &Path, scope: ChangeScope) -> Self {
+        let original_workspace_root = workspace_root.to_path_buf();
         let workspace_root = workspace_root
             .canonicalize()
-            .unwrap_or_else(|_| workspace_root.to_path_buf());
+            .unwrap_or_else(|_| original_workspace_root.clone());
+        let scope = normalize_scope_paths(&original_workspace_root, &workspace_root, scope);
         let before = snapshot::collect_snapshot(&workspace_root, &scope.targets);
         Self {
             workspace_root,
@@ -88,6 +90,22 @@ impl ChangeSession {
         let after = snapshot::collect_snapshot(&self.workspace_root, &self.scope.targets);
         diff::diff_snapshots(&self.before, &after)
     }
+}
+
+// Canonicalizing a workspace can change the root spelling (for example
+// macOS /var -> /private/var) or resolve a symlink. Keep targets that were
+// built from the original root in the same path namespace as the snapshot root.
+fn normalize_scope_paths(
+    original_workspace_root: &Path,
+    canonical_workspace_root: &Path,
+    mut scope: ChangeScope,
+) -> ChangeScope {
+    for target in &mut scope.targets {
+        if let Ok(relative) = target.path.strip_prefix(original_workspace_root) {
+            target.path = canonical_workspace_root.join(relative);
+        }
+    }
+    scope
 }
 
 #[cfg(test)]
@@ -242,6 +260,30 @@ mod tests {
         assert_eq!(changes.len(), 1);
         assert_eq!(changes[0].path, ".env");
 
+        let _ = fs::remove_dir_all(root);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_workspace_root_keeps_target_paths_workspace_relative() {
+        use std::os::unix::fs::symlink;
+
+        let root = workspace("canonical-root");
+        let alias = root.with_extension("alias");
+        fs::write(root.join("tracked.txt"), "before\n").expect("write tracked");
+        symlink(&root, &alias).expect("create workspace symlink");
+
+        let session = ChangeSession::begin(
+            &alias,
+            ChangeScope::single(ChangeTarget::explicit(alias.join("tracked.txt"), false)),
+        );
+        fs::write(root.join("tracked.txt"), "after\n").expect("change tracked");
+
+        let changes = session.changes();
+        assert_eq!(changes.len(), 1);
+        assert_eq!(changes[0].path, "tracked.txt");
+
+        let _ = fs::remove_file(alias);
         let _ = fs::remove_dir_all(root);
     }
 


### PR DESCRIPTION
## Summary

Fix change tracking paths becoming absolute when the workspace root resolves to a different canonical path.

This also fixes the six existing `change_tracking` test failures on macOS.

## Root cause

`ChangeSession::begin` canonicalizes the workspace root before collecting snapshots, but the paths stored in `ChangeTarget` previously kept their original form.

On macOS, temporary paths commonly expose this difference:

`/var/folders/...`

may canonicalize to:

`/private/var/folders/...`

This caused operations such as `path.strip_prefix(workspace_root)` to fail because the target path and workspace root no longer shared the same prefix representation.

When that happened, change tracking fell back to the original absolute path instead of producing a workspace-relative path.

## Fix

When the workspace root is canonicalized, target paths that are inside the original workspace are now remapped onto the canonical workspace root while preserving their relative suffix.

For example:

* original workspace: `/var/.../project`
* canonical workspace: `/private/var/.../project`
* target: `/var/.../project/src/main.rs`

becomes:

`/private/var/.../project/src/main.rs`

before snapshot collection.

This keeps the workspace root and target paths in the same path namespace without canonicalizing individual targets or following file symlinks.

## Regression coverage

Added a Unix regression test using a symlinked workspace root to reproduce the same class of path mismatch on platforms other than macOS.

The test verifies that change tracking still returns `tracked.txt` instead of an absolute path.

## Validation

Targeted change-tracking tests:

**9 passed, 0 failed**

Full test suite:

**215 passed, 0 failed**

Additional validation:

* `cargo build --release` ✅
* `rustfmt --check` ✅
* `git diff --check` ✅

## Scope

Only `src/change_tracking/mod.rs` is changed.

No ignore rules, diff generation, MCP behavior, or configuration formats are modified.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed change tracking when a workspace is opened through a symbolic link.
  * Reported change paths now remain correctly relative to the workspace, matching the snapshot root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->